### PR TITLE
Issue #12 - UIGraphicsImageRenderer should applying scaling

### DIFF
--- a/SwiftDraw/UIImage+Image.swift
+++ b/SwiftDraw/UIImage+Image.swift
@@ -85,8 +85,9 @@ public extension SVG {
 
     func rasterize(with size: CGSize? = nil, scale: CGFloat = 0, insets: UIEdgeInsets = .zero) -> UIImage {
         let insets = Insets(top: insets.top, left: insets.left, bottom: insets.bottom, right: insets.right)
-        let (bounds, pixelsWide, pixelsHigh) = makeBounds(size: size, scale: scale, insets: insets)
+        let (bounds, pixelsWide, pixelsHigh) = makeBounds(size: size, scale: 1, insets: insets)
         let f = makeFormat()
+        f.scale = scale
         f.opaque = false
         let r = UIGraphicsImageRenderer(size: CGSize(width: pixelsWide, height: pixelsHigh), format: f)
         return r.image{

--- a/SwiftDrawTests/UIImage+ImageTests.swift
+++ b/SwiftDrawTests/UIImage+ImageTests.swift
@@ -37,15 +37,56 @@ import UIKit
 
 final class UIImageTests: XCTestCase {
 
-  func testImageLoads() {
-    let image = UIImage(svgNamed: "lines.svg", in: .test)
-    XCTAssertNotNil(image)
-  }
+    func testImageLoads() {
+        let image = UIImage(svgNamed: "lines.svg", in: .test)
+        XCTAssertNotNil(image)
+    }
 
-  func testMissingImageDoesNotLoad() {
-    let image = UIImage(svgNamed: "missing.svg", in: .test)
-    XCTAssertNil(image)
-  }
+    func testMissingImageDoesNotLoad() {
+        let image = UIImage(svgNamed: "missing.svg", in: .test)
+        XCTAssertNil(image)
+    }
+
+    func testImageSize() throws {
+        let image = try SVG.parse(#"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            </svg>
+            """#
+        )
+    
+        XCTAssertEqual(
+            image.rasterize(scale: 1).size,
+            CGSize(width: 64, height: 64)
+        )
+        XCTAssertEqual(
+            image.rasterize(scale: 1).scale,
+            1
+        )
+        XCTAssertEqual(
+            image.rasterize(scale: 2).size,
+            CGSize(width: 64, height: 64)
+        )
+        XCTAssertEqual(
+            image.rasterize(scale: 2).scale,
+            2
+        )
+    }
 }
 
 #endif
+
+private extension SVG {
+
+    static func parse(_ code: String) throws -> SVG {
+        guard let data = code.data(using: .utf8),
+              let svg = SVG(data: data)  else {
+            throw InvalidSVG()
+        }
+        return svg
+    }
+
+    private struct InvalidSVG: LocalizedError {
+        var errorDescription: String? = "Invalid SVG"
+    }
+}


### PR DESCRIPTION
[0.13.0](https://github.com/swhitty/SwiftDraw/releases/tag/0.13.0) introduced a regression where images rasterized to `UIImage` would be scaled twice.

`UIGraphicsImageRenderer` should apply scale and image should be sized in points (scale 1) 

https://github.com/swhitty/SwiftDraw/issues/12