### PR TITLE
Mac Catalyst Support

### DIFF
--- a/SwiftDraw/NSImage+Image.swift
+++ b/SwiftDraw/NSImage+Image.swift
@@ -29,7 +29,7 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import CoreGraphics
 


### PR DESCRIPTION
check `targetEnvironment(macCatalyst)` so that SwiftDraw successfully builds for Mac Catalyst. 

Fixes https://github.com/swhitty/SwiftDraw/issues/15