### PR TITLE
Only wind fill paths

### DIFF
--- a/Samples.bundle/spy-glass.svg
+++ b/Samples.bundle/spy-glass.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.5 19L13.5 13L19.5 19ZM8.5 1C4.63401 1 1.5 4.13401 1.5 8C1.5 11.866 4.63401 15 8.5 15C10.3565 15 12.137 14.2625 13.4497 12.9497C14.7625 11.637 15.5 9.85652 15.5 8C15.5 4.13401 12.366 1 8.5 1Z" stroke="#20211F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SwiftDraw/Renderer.SFSymbol.swift
+++ b/SwiftDraw/Renderer.SFSymbol.swift
@@ -202,9 +202,7 @@ extension SFSymbolRenderer {
                     } else {
                         paths.append(SymbolPath(class: symbolClass, path: fillPath.applying(matrix: ctm)))
                     }
-                }
-
-                if let strokePath = makeStrokePath(for: shape, stroke: stroke, preserve: isSFSymbolLayer) {
+                } else if let strokePath = makeStrokePath(for: shape, stroke: stroke, preserve: isSFSymbolLayer) {
                     paths.append(SymbolPath(class: symbolClass, path: strokePath.applying(matrix: ctm)))
                 }
 


### PR DESCRIPTION
SFSymbols using `fill-rule: evenOdd` need to be converted to non [zero winding rule](https://en.wikipedia.org/wiki/Nonzero-rule) only when filling.

When a path is stroked — expanded on Darwin platforms using with [`replacePathWithStrokedPath()`](https://developer.apple.com/documentation/coregraphics/cgcontext/1454517-replacepathwithstrokedpath), then no conversion is required.