### PR TITLE
Fixing winding when out of order

### DIFF
--- a/SwiftDraw/LayerTree.Path+Reversed.swift
+++ b/SwiftDraw/LayerTree.Path+Reversed.swift
@@ -66,11 +66,17 @@ private extension LayerTree.Path {
         var nodes = [SubPathNode]()
 
         for p in subpaths {
-            let node = SubPathNode(p)
+            var node = SubPathNode(p)
             if let idx = nodes.firstIndex(where: { $0.containsNode(node) }) {
                 nodes[idx].append(node)
             } else {
-                nodes.append(node)
+                if let idx = nodes.firstIndex(where: { node.containsNode($0) }) {
+                    // existing node is inside new node
+                    node.append(nodes[idx])
+                    nodes[idx] = node
+                } else {
+                    nodes.append(node)
+                }
             }
         }
         return nodes
@@ -105,7 +111,14 @@ private struct SubPathNode {
         if let idx = children.firstIndex(where: { $0.containsNode(node) }) {
             children[idx].append(node)
         } else {
-            children.append(node)
+            if let idx = children.firstIndex(where: { node.containsNode($0) }) {
+                // existing node is inside new node
+                var node = node
+                node.append(children[idx])
+                children[idx] = node
+            } else {
+                children.append(node)
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug within the autowinding of subpaths for SFSymbols that I believe has always existed but was amplified by 
https://github.com/swhitty/SwiftDraw/pull/33.

When paths are winded, they need to be sorted into a trees to calculate which paths are "inside" other paths.  The sorting code was previously relying on the outer paths being added to the tree first, the algorithm now checks if the new node should be swapped with an existing node.

Resolves #32 