### PR TITLE
Support absolute units for any position, size or coordinate

### DIFF
--- a/Examples/Sources/ViewController.swift
+++ b/Examples/Sources/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
 
     override func loadView() {
         let imageView = UIImageView(frame: UIScreen.main.bounds)
-        imageView.image = SVG(named: "usa.svg", in: .samples)?.rasterize()
+        imageView.image = SVG(named: "units-cm.svg", in: .samples)?.rasterize()
         imageView.contentMode = .scaleAspectFit
         imageView.backgroundColor = .white
         self.view = imageView

--- a/Samples.bundle/units-cm.svg
+++ b/Samples.bundle/units-cm.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>	 
+<svg height="10cm" width="10cm" xmlns="http://www.w3.org/2000/svg">
+	<rect width="10cm" height="10cm" fill="snow" />
+    <polygon points="100,10 40,180 190,60 10,60 160,180" style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />
+</svg>

--- a/Samples.bundle/units.svg
+++ b/Samples.bundle/units.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>	 
+<svg height="17pc" width="5in" xmlns="http://www.w3.org/2000/svg">
+
+ 	<rect width="5in" height="17pc" fill="snow" />
+	
+	<rect x="2cm" y="3cm" width="2in" height="7.5pc" fill="red" />
+	
+	<rect x="35" y="1.5cm" width="200" height="2pc" fill="blue" />
+
+</svg>

--- a/SwiftDraw/DOM.swift
+++ b/SwiftDraw/DOM.swift
@@ -104,8 +104,55 @@ extension DOM {
         case skewX(angle: Float)
         case skewY(angle: Float)
     }
-    
+
+    enum Unit {
+        case pixel
+        case inch
+        case centimeter
+        case millimeter
+        case point
+        case pica
+    }
+
     enum Error: Swift.Error {
         case missing(String)
+    }
+}
+
+extension DOM.Unit {
+    var rawValue: String {
+        switch self {
+        case .pixel:
+            return "px"
+        case .inch:
+            return "in"
+        case .centimeter:
+            return "cm"
+        case .millimeter:
+            return "mm"
+        case .point:
+            return "pt"
+        case .pica:
+            return "pc"
+        }
+    }
+}
+
+extension Double {
+    func apply(unit: DOM.Unit) -> Double {
+        switch unit {
+        case .pixel:
+            return self
+        case .inch:
+            return self * 96
+        case .centimeter:
+            return self * 37.795
+        case .millimeter:
+            return self * 3.7795
+        case .point:
+            return self * 1.3333
+        case .pica:
+            return self * 16
+        }
     }
 }

--- a/SwiftDraw/Parser.XML.Scanner.swift
+++ b/SwiftDraw/Parser.XML.Scanner.swift
@@ -155,7 +155,34 @@ extension XMLParser {
             currentIndex = scanner.currentIndex
             return val
         }
-        
+
+        mutating func scanUnit(_ unit: DOM.Unit) -> Bool {
+            scanner.currentIndex = currentIndex
+            guard scanner.scanString(unit.rawValue) != nil else {
+                return false
+            }
+            currentIndex = scanner.currentIndex
+            return true
+        }
+
+        mutating func scanUnit() -> DOM.Unit? {
+            if scanUnit(.pixel) {
+                return .pixel
+            } else if scanUnit(.inch) {
+                return .inch
+            } else if scanUnit(.centimeter) {
+                return .centimeter
+            } else if scanUnit(.millimeter) {
+                return .millimeter
+            } else if scanUnit(.point) {
+                return .point
+            } else if scanUnit(.pica) {
+                return .pica
+            } else {
+                return nil
+            }
+        }
+
         mutating func scanLength() throws -> DOM.Length {
             scanner.currentIndex = currentIndex
             guard
@@ -173,7 +200,9 @@ extension XMLParser {
         }
         
         mutating func scanCoordinate() throws -> DOM.Coordinate {
-            return DOM.Coordinate(try scanDouble())
+            let double = try scanDouble()
+            let unit = scanUnit() ?? .pixel
+            return DOM.Coordinate(double.apply(unit: unit))
         }
         
         mutating func scanPercentageFloat() throws -> Float {

--- a/SwiftDrawTests/XML.Parser.ScannerTests.swift
+++ b/SwiftDrawTests/XML.Parser.ScannerTests.swift
@@ -181,6 +181,22 @@ final class ScannerTests: XCTestCase {
     _ = try? scanner.scanString(",")
     XCTAssertEqual(try scanner.scanCoordinate(), -10)
   }
+
+    func testScanCoordinate_Units() throws {
+        var scanner = XMLParser.Scanner(text: "1, 2px, 1cm, 2mm, 1pt, 5pc")
+
+        XCTAssertEqual(try scanner.scanCoordinate(), 1)
+        _ = try? scanner.scanString(",")
+        XCTAssertEqual(try scanner.scanCoordinate(), 2)
+        _ = try? scanner.scanString(",")
+        XCTAssertEqual(try scanner.scanCoordinate(), 37.795)
+        _ = try? scanner.scanString(",")
+        XCTAssertEqual(try scanner.scanCoordinate(), 2 * 3.7795)
+        _ = try? scanner.scanString(",")
+        XCTAssertEqual(try scanner.scanCoordinate(), 1 * 1.3333)
+        _ = try? scanner.scanString(",")
+        XCTAssertEqual(try scanner.scanCoordinate(), 5 * 16)
+    }
 }
 
 private func AssertScanUInt8(_ text: String, _ expected: UInt8?, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Any SVG position, size or coordinate can be specified with a unit (absolute or relative).  This PR adds support for absolute units that can be explicated converted to pixels using [predefined constants.](https://oreillymedia.github.io/Using_SVG/guide/units.html):
- pixel
- inch
- centimeter
- millimeter
- point
- pica

```svg
<?xml version="1.0" encoding="utf-8"?>	 
<svg height="10cm" width="10cm" xmlns="http://www.w3.org/2000/svg">
    <rect width="10cm" height="10cm" fill="snow" />
    <polygon points="100,10 40,180 190,60 10,60 160,180" style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />
</svg>
```
![units-cm](https://github.com/swhitty/SwiftDraw/assets/867662/397f5e06-38b2-4853-99b6-7086a9f48bee)

