### PR TITLE
Add support for RGBA values

### DIFF
--- a/Examples/Sources/ViewController.swift
+++ b/Examples/Sources/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
 
     override func loadView() {
         let imageView = UIImageView(frame: UIScreen.main.bounds)
-        imageView.image = SVG(named: "units-cm.svg", in: .samples)?.rasterize()
+        imageView.image = SVG(named: "rgba.svg", in: .samples)?.rasterize()
         imageView.contentMode = .scaleAspectFit
         imageView.backgroundColor = .white
         self.view = imageView

--- a/Samples.bundle/rgba.svg
+++ b/Samples.bundle/rgba.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
-  <path fill="rgba(250, 140, 0, 0.35)" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
+  <path fill="rgba(250, 140, 0, 0.85)" fill-rule="evenodd" fill-opacity="0.5" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
   <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
   <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
 </svg>

--- a/Samples.bundle/rgba.svg
+++ b/Samples.bundle/rgba.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <path fill="rgba(250, 140, 0, 0.35)" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
+  <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
+  <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
+</svg>

--- a/Samples.bundle/rgba.svg
+++ b/Samples.bundle/rgba.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
-  <path fill="rgba(250, 140, 0, 0.85)" fill-rule="evenodd" fill-opacity="0.5" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
+  <path fill="rgba(98%, 54%, 0%, 0.85)" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
   <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
   <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
 </svg>

--- a/SwiftDraw/DOM.Color.swift
+++ b/SwiftDraw/DOM.Color.swift
@@ -35,11 +35,10 @@ extension DOM {
         case none
         case currentColor
         case keyword(Keyword)
-        case rgbi(UInt8, UInt8, UInt8)
-        case rgbf(DOM.Float, DOM.Float, DOM.Float)
+        case rgbi(UInt8, UInt8, UInt8, DOM.Float)
+        case rgbf(DOM.Float, DOM.Float, DOM.Float, DOM.Float)
         case p3(DOM.Float, DOM.Float, DOM.Float)
         case hex(UInt8, UInt8, UInt8)
-        case rgba(UInt8, UInt8, UInt8, DOM.Float)
         
         // see: https://www.w3.org/TR/SVG11/types.html#ColorKeywords
         enum Keyword: String {

--- a/SwiftDraw/DOM.Color.swift
+++ b/SwiftDraw/DOM.Color.swift
@@ -39,6 +39,7 @@ extension DOM {
         case rgbf(DOM.Float, DOM.Float, DOM.Float)
         case p3(DOM.Float, DOM.Float, DOM.Float)
         case hex(UInt8, UInt8, UInt8)
+        case rgba(UInt8, UInt8, UInt8, DOM.Float)
         
         // see: https://www.w3.org/TR/SVG11/types.html#ColorKeywords
         enum Keyword: String {

--- a/SwiftDraw/LayerTree.Color.swift
+++ b/SwiftDraw/LayerTree.Color.swift
@@ -74,6 +74,8 @@ extension LayerTree.Color {
                    b: Float(b),
                    a: 1.0,
                    space: .p3)
+    case let .rgba(r, g, b, a):
+      return LayerTree.Color(r, g, b, a)
     }
   }
 
@@ -82,6 +84,14 @@ extension LayerTree.Color {
                  g: Float(g)/255.0,
                  b: Float(b)/255.0,
                  a: 1.0,
+                 space: .srgb)
+  }
+  
+  init(_ r: UInt8, _ g: UInt8, _ b: UInt8, _ a: DOM.Float) {
+    self = .rgba(r: Float(r)/255.0,
+                 g: Float(g)/255.0,
+                 b: Float(b)/255.0,
+                 a: a,
                  space: .srgb)
   }
 

--- a/SwiftDraw/LayerTree.Color.swift
+++ b/SwiftDraw/LayerTree.Color.swift
@@ -110,14 +110,14 @@ extension LayerTree.Color {
     switch self {
     case .none:
       return .none
-    case let .rgba(r: r, g: g, b: b, a: _, space):
+    case let .rgba(r: r, g: g, b: b, a: a, space):
       return .rgba(r: r,
                    g: g,
                    b: b,
-                   a: alpha,
+                   a: alpha * a,
                    space: space)
-    case .gray(white: let w, a: _):
-      return .gray(white: w, a: alpha)
+    case .gray(white: let w, a: let a):
+      return .gray(white: w, a: alpha * a)
     }
   }
   

--- a/SwiftDraw/LayerTree.Color.swift
+++ b/SwiftDraw/LayerTree.Color.swift
@@ -58,15 +58,15 @@ extension LayerTree.Color {
     case let .keyword(c):
       let rgbi = c.rgbi
       return LayerTree.Color(rgbi.0, rgbi.1, rgbi.2)
-    case let .rgbi(r, g, b):
-      return LayerTree.Color(r, g, b)
+    case let .rgbi(r, g, b, a):
+      return LayerTree.Color(r, g, b, Float(a))
     case let .hex(r, g, b):
       return LayerTree.Color(r, g, b)
-    case let .rgbf(r, g, b):
+    case let .rgbf(r, g, b, a):
       return .rgba(r: Float(r),
                    g: Float(g),
                    b: Float(b),
-                   a: 1.0,
+                   a: Float(a),
                    space: .srgb)
     case let .p3(r, g, b):
       return .rgba(r: Float(r),
@@ -74,8 +74,6 @@ extension LayerTree.Color {
                    b: Float(b),
                    a: 1.0,
                    space: .p3)
-    case let .rgba(r, g, b, a):
-      return LayerTree.Color(r, g, b, a)
     }
   }
 

--- a/SwiftDraw/Parser.XML.Color.swift
+++ b/SwiftDraw/Parser.XML.Color.swift
@@ -91,6 +91,17 @@ extension XMLParser {
     return try parseColorRGBi(data: data)
   }
   
+  private func parseColorRGBA(data: String) throws -> DOM.Color? {
+    var scanner = XMLParser.Scanner(text: data)
+    guard scanner.scanStringIfPossible("rgba(") else { return nil }
+    
+    if let c = try? parseColorRGBAf(data: data) {
+      return c
+    }
+    
+    return try parseColorRGBAi(data: data)
+  }
+  
   private func parseURLSelector(data: String) throws -> DOM.URL? {
     var scanner = XMLParser.Scanner(text: data)
     guard (try? scanner.scanString("url(")) == true else {
@@ -109,32 +120,63 @@ extension XMLParser {
     return url
   }
   
-  private func parseColorRGBi(data: String) throws -> DOM.Color {
+  private func parseIntColor(data: String, withAlpha: Bool) throws -> DOM.Color {
     var scanner = XMLParser.Scanner(text: data)
-    try scanner.scanString("rgb(")
+    try scanner.scanString(withAlpha ? "rgba(" : "rgb(")
     
     let r = try scanner.scanUInt8()
     scanner.scanStringIfPossible(",")
     let g = try scanner.scanUInt8()
     scanner.scanStringIfPossible(",")
     let b = try scanner.scanUInt8()
+    var a: Float = 1.0
+    
+    if withAlpha {
+      scanner.scanStringIfPossible(",")
+      a = try scanner.scanFloat()  // Opacity
+    }
+    
     try scanner.scanString(")")
-    return .rgbi(r, g, b)
+    return .rgbi(r, g, b, a)
   }
   
-  private func parseColorRGBf(data: String) throws -> DOM.Color {
+  private func parseColorRGBi(data: String) throws -> DOM.Color {
+    return try parseIntColor(data: data, withAlpha: false)
+  }
+  
+  private func parseColorRGBAi(data: String) throws -> DOM.Color {
+    return try parseIntColor(data: data, withAlpha: true)
+  }
+  
+  private func parsePercentageColor(data: String, withAlpha: Bool) throws -> DOM.Color {
     var scanner = XMLParser.Scanner(text: data)
-    try scanner.scanString("rgb(")
+    try scanner.scanString(withAlpha ? "rgba(" : "rgb(")
     
     let r = try scanner.scanPercentage()
     scanner.scanStringIfPossible(",")
     let g = try scanner.scanPercentage()
     scanner.scanStringIfPossible(",")
     let b = try scanner.scanPercentage()
+    
+    var a: Float = 1.0
+    if withAlpha {
+      scanner.scanStringIfPossible(",")
+      a = try scanner.scanFloat()  // Opacity
+    }
+    
     try scanner.scanString(")")
     
-    return .rgbf(r, g, b)
+    return .rgbf(r, g, b, a)
   }
+  
+  private func parseColorRGBf(data: String) throws -> DOM.Color {
+    return try parsePercentageColor(data: data, withAlpha: false)
+  }
+  
+  private func parseColorRGBAf(data: String) throws -> DOM.Color {
+    return try parsePercentageColor(data: data, withAlpha: true)
+  }
+
   
   private func parseColorP3(data: String) throws -> DOM.Color? {
     var scanner = XMLParser.Scanner(text: data)
@@ -174,21 +216,5 @@ extension XMLParser {
     let b = UInt8(hex & 0xff)
     
     return .hex(r, g, b)
-  }
-  
-  private func parseColorRGBA(data: String) throws -> DOM.Color? {
-    var scanner = XMLParser.Scanner(text: data)
-    try scanner.scanString("rgba(")
-    
-    let r = try scanner.scanUInt8()
-    scanner.scanStringIfPossible(",")
-    let g = try scanner.scanUInt8()
-    scanner.scanStringIfPossible(",")
-    let b = try scanner.scanUInt8()
-    scanner.scanStringIfPossible(",")
-    let a = try scanner.scanFloat()  // Opacity
-    try scanner.scanString(")")
-    
-    return .rgba(r, g, b, a)
   }
 }

--- a/SwiftDraw/Parser.XML.Color.swift
+++ b/SwiftDraw/Parser.XML.Color.swift
@@ -49,6 +49,8 @@ extension XMLParser {
       return .color(c)
     } else if let url = try parseURLSelector(data: data) {
       return .url(url)
+    } else if let c = try parseColorRGBA(data: data) {
+      return .color(c)
     }
     
     throw Error.invalid
@@ -172,5 +174,21 @@ extension XMLParser {
     let b = UInt8(hex & 0xff)
     
     return .hex(r, g, b)
+  }
+  
+  private func parseColorRGBA(data: String) throws -> DOM.Color? {
+    var scanner = XMLParser.Scanner(text: data)
+    try scanner.scanString("rgba(")
+    
+    let r = try scanner.scanUInt8()
+    scanner.scanStringIfPossible(",")
+    let g = try scanner.scanUInt8()
+    scanner.scanStringIfPossible(",")
+    let b = try scanner.scanUInt8()
+    scanner.scanStringIfPossible(",")
+    let a = try scanner.scanFloat()  // Opacity
+    try scanner.scanString(")")
+    
+    return .rgba(r, g, b, a)
   }
 }

--- a/SwiftDraw/XML.Formatter.SVG.swift
+++ b/SwiftDraw/XML.Formatter.SVG.swift
@@ -296,14 +296,22 @@ extension XML.Formatter {
             case let .keyword(k):
                 return k.rawValue
             case let .rgbi(r, g, b, a):
-                let aa = String(format: "%.2f", a)
-                return "rgb(\(r), \(g), \(b), \(aa)"
+                if a == 1.0 {
+                    return "rgb(\(r), \(g), \(b))"
+                } else {
+                    let aa = String(format: "%.2f", a)
+                    return "rgba(\(r), \(g), \(b), \(aa))"
+                }
             case let .rgbf(r, g, b, a):
                 let rr = String(format: "%.0f", r * 100)
                 let gg = String(format: "%.0f", g * 100)
                 let bb = String(format: "%.0f", b * 100)
-                let aa = String(format: "%.2f", a)
-                return "rgb(\(rr)%, \(gg)%, \(bb)%, \(aa)"
+                if a == 1.0 {
+                    return "rgb(\(rr)%, \(gg)%, \(bb)%)"
+                } else {
+                    let aa = String(format: "%.2f", a)
+                    return "rgba(\(rr)%, \(gg)%, \(bb)%, \(aa))"
+                }
             case let .p3(r, g, b):
                 return "color(display-p3 \(r), \(g), \(b))"
             case let .hex(r, g, b):

--- a/SwiftDraw/XML.Formatter.SVG.swift
+++ b/SwiftDraw/XML.Formatter.SVG.swift
@@ -295,13 +295,15 @@ extension XML.Formatter {
                 return "currentColor"
             case let .keyword(k):
                 return k.rawValue
-            case let .rgbi(r, g, b):
-                return "rgb(\(r), \(g), \(b))"
-            case let .rgbf(r, g, b):
+            case let .rgbi(r, g, b, a):
+                let aa = String(format: "%.2f", a)
+                return "rgb(\(r), \(g), \(b), \(aa)"
+            case let .rgbf(r, g, b, a):
                 let rr = String(format: "%.0f", r * 100)
                 let gg = String(format: "%.0f", g * 100)
                 let bb = String(format: "%.0f", b * 100)
-                return "rgb(\(rr)%, \(gg)%, \(bb)%)"
+                let aa = String(format: "%.2f", a)
+                return "rgb(\(rr)%, \(gg)%, \(bb)%, \(aa)"
             case let .p3(r, g, b):
                 return "color(display-p3 \(r), \(g), \(b))"
             case let .hex(r, g, b):
@@ -309,9 +311,6 @@ extension XML.Formatter {
                 let gg = String(format: "%02X", g)
                 let bb = String(format: "%02X", b)
                 return "#\(rr)\(gg)\(bb)"
-            case let .rgba(r, g, b, a):
-              let aa = String(format: "%.2f", a)
-              return "rgba(\(r), \(g), \(b), \(aa))"
             }
         }
 

--- a/SwiftDraw/XML.Formatter.SVG.swift
+++ b/SwiftDraw/XML.Formatter.SVG.swift
@@ -309,6 +309,9 @@ extension XML.Formatter {
                 let gg = String(format: "%02X", g)
                 let bb = String(format: "%02X", b)
                 return "#\(rr)\(gg)\(bb)"
+            case let .rgba(r, g, b, a):
+              let aa = String(format: "%.2f", a)
+              return "rgba(\(r), \(g), \(b), \(aa))"
             }
         }
 

--- a/SwiftDrawTests/LayerTree.BuilderTests.swift
+++ b/SwiftDrawTests/LayerTree.BuilderTests.swift
@@ -106,7 +106,7 @@ final class LayerTreeBuilderTests: XCTestCase {
   
   func testStrokeAttributes() {
     var state = LayerTree.Builder.State()
-      state.stroke = .color(.rgbf(1.0, 0.0, 0.0))
+    state.stroke = .color(.rgbf(1.0, 0.0, 0.0, 1.0))
     state.strokeOpacity = 0.5
     state.strokeWidth = 5.0
     state.strokeLineCap = .square

--- a/SwiftDrawTests/LayerTree.ColorTests.swift
+++ b/SwiftDrawTests/LayerTree.ColorTests.swift
@@ -119,9 +119,9 @@ final class LayerTreeColorTests: XCTestCase {
     let none = DOM.Color.none
     let black = DOM.Color.keyword(.black)
     let white = DOM.Color.keyword(.white)
-    let red = DOM.Color.rgbi(255, 0, 0)
-    let green = DOM.Color.rgbi(0, 255, 0)
-    let blue = DOM.Color.rgbi(0, 0, 255)
+    let red = DOM.Color.rgbi(255, 0, 0, 1.0)
+    let green = DOM.Color.rgbi(0, 255, 0, 1.0)
+    let blue = DOM.Color.rgbi(0, 0, 255, 1.0)
     
     XCTAssertEqual(Color(none), .none)
     XCTAssertEqual(Color(black), .srgb(r: 0.0, g: 0.0, b: 0.0, a: 1.0))

--- a/SwiftDrawTests/NSImage+ImageTests.swift
+++ b/SwiftDrawTests/NSImage+ImageTests.swift
@@ -72,8 +72,8 @@ private extension SVG {
     let svg = DOM.SVG(width: 2, height: 2)
     svg.childElements.append(DOM.Rect(x: 0, y: 0, width: 1, height: 1))
     svg.childElements.append(DOM.Rect(x: 1, y: 1, width: 1, height: 1))
-    svg.childElements[0].attributes.fill = .color(DOM.Color.rgbi(255, 0, 0))
-    svg.childElements[1].attributes.fill = .color(DOM.Color.rgbi(0, 0, 255))
+    svg.childElements[0].attributes.fill = .color(DOM.Color.rgbi(255, 0, 0, 1.0))
+    svg.childElements[1].attributes.fill = .color(DOM.Color.rgbi(0, 0, 255, 1.0))
     return SVG(dom: svg, options: .default)
   }
 }

--- a/SwiftDrawTests/Parser.XML.ColorTests.swift
+++ b/SwiftDrawTests/Parser.XML.ColorTests.swift
@@ -63,16 +63,27 @@ final class ParserColorTests: XCTestCase {
   
   func testColorRGBi() {
     // integer 0-255
-    XCTAssertEqual(try XMLParser().parseColor("rgb(0,1,2)"), .rgbi(0, 1, 2))
-    XCTAssertEqual(try XMLParser().parseColor(" rgb( 0 , 1 , 2) "), .rgbi(0, 1, 2))
-    XCTAssertEqual(try XMLParser().parseColor("rgb(255,100,78)"), .rgbi(255, 100, 78))
+    XCTAssertEqual(try XMLParser().parseColor("rgb(0,1,2)"), .rgbi(0, 1, 2, 1.0))
+    XCTAssertEqual(try XMLParser().parseColor(" rgb( 0 , 1 , 2) "), .rgbi(0, 1, 2, 1.0))
+    XCTAssertEqual(try XMLParser().parseColor("rgb(255,100,78)"), .rgbi(255, 100, 78, 1.0))
   }
   
   func testColorRGBf() {
     // percentage 0-100%
-    XCTAssertEqual(try XMLParser().parseColor("rgb(0,1%,99%)"), .rgbf(0.0, 0.01, 0.99))
-    XCTAssertEqual(try XMLParser().parseColor("rgb( 0%, 52% , 100%) "), .rgbf(0.0, 0.52, 1.0))
-    XCTAssertEqual(try XMLParser().parseColor("rgb(75%,25%,7%)"), .rgbf(0.75, 0.25, 0.07))
+    XCTAssertEqual(try XMLParser().parseColor("rgb(0,1%,99%)"), .rgbf(0.0, 0.01, 0.99, 1.0))
+    XCTAssertEqual(try XMLParser().parseColor("rgb( 0%, 52% , 100%) "), .rgbf(0.0, 0.52, 1.0, 1.0))
+    XCTAssertEqual(try XMLParser().parseColor("rgb(75%,25%,7%)"), .rgbf(0.75, 0.25, 0.07, 1.0))
+  }
+  
+  func testColorRGBA() {
+    // integer 0-255
+    XCTAssertEqual(try XMLParser().parseColor("rgba(0,1,2,0.5)"), .rgbi(0, 1, 2, 0.5))
+    XCTAssertEqual(try XMLParser().parseColor(" rgba( 0 , 1 , 2, 0.6) "), .rgbi(0, 1, 2, 0.6))
+    XCTAssertEqual(try XMLParser().parseColor("rgba(255,100,78,0.7)"), .rgbi(255, 100, 78, 0.7))
+    // percentage 0-100%
+    XCTAssertEqual(try XMLParser().parseColor("rgba(0,1%,99%,0.5)"), .rgbf(0.0, 0.01, 0.99, 0.5))
+    XCTAssertEqual(try XMLParser().parseColor("rgba( 0%, 52% , 100%, 0.6) "), .rgbf(0.0, 0.52, 1.0, 0.6))
+    XCTAssertEqual(try XMLParser().parseColor("rgba(75%,25%,7%,0.7)"), .rgbf(0.75, 0.25, 0.07, 0.7))
   }
   
   func testColorHex() {

--- a/SwiftDrawTests/ValueParserTests.swift
+++ b/SwiftDrawTests/ValueParserTests.swift
@@ -111,8 +111,10 @@ final class ValueParserTests: XCTestCase {
     XCTAssertEqual(try parser.parseFill("black"), .color(.keyword(.black)))
     XCTAssertEqual(try parser.parseFill("red"), .color(.keyword(.red)))
     
-    XCTAssertEqual(try parser.parseFill("rgb(10,20,30)"), .color(.rgbi(10, 20, 30)))
-    XCTAssertEqual(try parser.parseFill("rgb(10%,20%,100%)"), .color(.rgbf(0.1, 0.2, 1.0)))
+    XCTAssertEqual(try parser.parseFill("rgb(10,20,30)"), .color(.rgbi(10, 20, 30, 1.0)))
+    XCTAssertEqual(try parser.parseFill("rgb(10%,20%,100%)"), .color(.rgbf(0.1, 0.2, 1.0, 1.0)))
+    XCTAssertEqual(try parser.parseFill("rgba(10, 20, 30, 0.5)"), .color(.rgbi(10, 20, 30, 0.5)))
+    XCTAssertEqual(try parser.parseFill("rgba(10%,20%,100%,0.6)"), .color(.rgbf(0.1, 0.2, 1.0, 0.6)))
     XCTAssertEqual(try parser.parseFill("#AAFF00"), .color(.hex(170, 255, 0)))
     
     XCTAssertEqual(try parser.parseFill("url(#test)"), .url(URL(string: "#test")!))


### PR DESCRIPTION
Parse and render RGBA values. RGBA values can now be parsed into `DOM.Color`, and when rendering, their alpha values are combined with any existing alpha values from styles.

Tested with:
- An inline color:
  ```xml
  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
    <path fill="rgba(250, 140, 0, 0.35)" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
    <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
    <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
  </svg>
  ```
  ![rgba](https://github.com/swhitty/SwiftDraw/assets/89362858/c348c054-b21d-4b83-a196-83ed78080b55)
  
- Color with `fill-opacity`:
  ```xml
  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
    <path fill="rgba(250, 140, 0, 0.85)" fill-rule="evenodd" fill-opacity="0.5" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
    <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
    <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
  </svg>
  ```
  ![rgba](https://github.com/swhitty/SwiftDraw/assets/89362858/61c74fba-9a19-4cbc-a671-e5b43393fcb1)

- A style color:
  ```xml
  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" style="color: rgba(250, 140, 0, 0.35);">
    <path fill="currentColor" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
    <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
    <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
  </svg>
  ```
  ![rgba-currentColor](https://github.com/swhitty/SwiftDraw/assets/89362858/7345eb48-8008-4200-8376-022a6e1a017d)

- A percentage color:
  ```xml
  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
    <path fill="rgba(98%, 54%, 0%, 0.85)" fill-rule="evenodd" d="M27.762 37.955H5.464C2.446 37.955 0 35.515 0 32.507c0-3.01 2.446-5.45 5.464-5.452l12.635-.006a5.813 5.813 0 0 1 5.037 2.9l4.626 8.006Z" clip-rule="evenodd"></path>
    <path fill="#FF3C5A" fill-rule="evenodd" d="M4.14 23.984 15.288 4.725a5.472 5.472 0 0 1 7.463-1.994 5.443 5.443 0 0 1 2.002 7.444l-6.312 10.916a5.813 5.813 0 0 1-5.038 2.9l-9.265-.007Z" clip-rule="evenodd"></path>
    <path fill="#FFC5CE" fill-rule="evenodd" d="m28.118 10.567 11.15 19.259a5.44 5.44 0 0 1-2 7.443 5.475 5.475 0 0 1-7.466-1.993l-6.324-10.91a5.781 5.781 0 0 1 .001-5.8l4.639-7.999Z" clip-rule="evenodd"></path>
  </svg>
  ```
  ![rgba](https://github.com/swhitty/SwiftDraw/assets/89362858/db839421-8de3-496c-8706-75b2b7d91923)