### PR TITLE
accept missing namespace

### DIFF
--- a/SwiftDraw/XML.SAXParser.swift
+++ b/SwiftDraw/XML.SAXParser.swift
@@ -45,7 +45,7 @@ extension XML {
 #endif
 
         private let parser: FoundationXMLParser
-        private let namespaceURI = "http://www.w3.org/2000/svg"
+        private let validNamespaces = Set(["http://www.w3.org/2000/svg", ""])
 
         private var rootNode: Element?
         private var elements: [Element]
@@ -84,10 +84,13 @@ extension XML {
             return try parse(data: data)
         }
 
+        func isValidNamespaceURI(_ uri: String?) -> Bool {
+            validNamespaces.contains(uri ?? "")
+        }
+
         func parser(_ parser: FoundationXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName _: String?, attributes attributeDict: [String: String] = [:]) {
             guard
-                self.parser === parser,
-                namespaceURI == self.namespaceURI else {
+                self.parser === parser, isValidNamespaceURI(namespaceURI) else {
                 return
             }
 
@@ -103,9 +106,7 @@ extension XML {
         }
 
         func parser(_ parser: FoundationXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName _: String?) {
-            guard
-                namespaceURI == self.namespaceURI,
-                currentElement.name == elementName else {
+            guard isValidNamespaceURI(namespaceURI), currentElement.name == elementName else {
                 return
             }
 

--- a/SwiftDrawTests/Parser.SVGTests.swift
+++ b/SwiftDrawTests/Parser.SVGTests.swift
@@ -133,4 +133,22 @@ final class ParserSVGTests: XCTestCase {
         let circle = try XCTUnwrap(svg.firstGraphicsElement(with: "b") as? DOM.Circle)
         XCTAssertEqual(circle.id, "b")
     }
+
+    func testMissingNamespce() throws {
+        let svg = try DOM.SVG.parse(xml: #"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="64" height="64" version="1.1">
+            <defs>
+                <rect id="a" x="10" y="20" width="30" height="40" />
+            </defs>
+            <circle id="b" cx="50" cy="60" r="70" />
+        </svg>
+        """#)
+
+        let rect = try XCTUnwrap(svg.firstGraphicsElement(with: "a") as? DOM.Rect)
+        XCTAssertEqual(rect.id, "a")
+
+        let circle = try XCTUnwrap(svg.firstGraphicsElement(with: "b") as? DOM.Circle)
+        XCTAssertEqual(circle.id, "b")
+    }
 }


### PR DESCRIPTION
Inline SVGs need not include the `xmlns="http://www.w3.org/2000/svg"` namespace.

While files are supposed to include it, I see no harm in accept a missing namespace for both types as the alternative is an error where nothing is displayed.