### PR TITLE
Swift 6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_report.lcov
 
+  xcode_26:
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
   xcode_16_2:
     runs-on: macos-15
     env:
@@ -45,33 +59,6 @@ jobs:
     runs-on: macos-14
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Version
-        run: swift --version
-      - name: Build
-        run: swift build --build-tests
-      - name: Test
-        run: swift test --skip-build
-
-  xcode_15_3:
-    runs-on: macos-14
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Version
-        run: swift --version
-      - name: Build
-        run: swift build --build-tests
-      - name: Test
-        run: swift test --skip-build
-
-  linux_5_9:
-    runs-on: ubuntu-latest
-    container: swift:5.9
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -111,6 +98,19 @@ jobs:
   linux_6_1:
     runs-on: ubuntu-latest
     container: swift:6.1.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
+  linux_swift_6_2:
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-6.2-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 
 import PackageDescription
 

--- a/SwiftDraw.podspec.json
+++ b/SwiftDraw.podspec.json
@@ -40,7 +40,7 @@
     "exclude_files": "SwiftDraw/NSImage+Image.swift",
     "frameworks": ["UIKit", "Foundation"]
   },
-  "swift_version": "5.9",
+  "swift_version": "5.10",
   "pod_target_xcconfig": {
     "OTHER_SWIFT_FLAGS": "-package-name SwiftDraw"
   },

--- a/SwiftDraw/Sources/SVG/SVG.swift
+++ b/SwiftDraw/Sources/SVG/SVG.swift
@@ -32,8 +32,8 @@
 import SwiftDrawDOM
 import Foundation
 
-#if compiler(<5.10)
-#warning("SwiftDraw will soon remove support for Swift 5.9")
+#if compiler(<6.0)
+#warning("SwiftDraw will soon remove support for Swift 5.10")
 #endif
 
 #if canImport(CoreGraphics)

--- a/SwiftDrawDOM.podspec.json
+++ b/SwiftDrawDOM.podspec.json
@@ -20,7 +20,7 @@
     "visionos": "1.0"
   },
   "source_files": "DOM/Sources/*.swift",
-  "swift_version": "5.9",
+  "swift_version": "5.10",
   "pod_target_xcconfig": {
     "OTHER_SWIFT_FLAGS": "-package-name SwiftDraw"
   }


### PR DESCRIPTION
Removing support for Swift 5.9

GitHub Actions now builds using Xcode 26 beta / Swift 6.2 nightlies