### PR TITLE
Handle empty Path definition

### DIFF
--- a/DOM/Sources/Parser.XML.Path.swift
+++ b/DOM/Sources/Parser.XML.Path.swift
@@ -50,6 +50,7 @@ package extension XMLParser {
     }
 
     func parsePathSegments(_ data: String) throws -> [Segment] {
+        guard !data.isEmpty else { return [] }
 
         var segments = Array<Segment>()
 


### PR DESCRIPTION
Currently, a file with an empty `Path` (`d=""`) will throw an error. I came across a file like that while generating SVGs using MathJax. Browsers and other tools seem to be render them fine.

Example (test.svg):

`...<path id="MJX-1-TEX-N-2061" d=""></path>...`

![test.svg](https://github.com/user-attachments/assets/cb064063-c831-4087-82ca-1f848c92f683)

Before:  

`swiftdraw test.svg --format png --size 500x200` fails.

After:  

`swiftdraw test.svg --format png --size 500x200` succeeds.
