### PR TITLE
handle path with just whitespace

### DIFF
--- a/DOM/Sources/DOM.Path.swift
+++ b/DOM/Sources/DOM.Path.swift
@@ -44,7 +44,7 @@ package extension DOM {
             super.init()
         }
         
-        package enum Segment {
+        package enum Segment: Equatable {
             case move(x: Coordinate, y: Coordinate, space: CoordinateSpace)
             case line(x: Coordinate, y: Coordinate, space: CoordinateSpace)
             case horizontal(x: Coordinate, space: CoordinateSpace)

--- a/DOM/Sources/Parser.XML.Path.swift
+++ b/DOM/Sources/Parser.XML.Path.swift
@@ -50,13 +50,15 @@ package extension XMLParser {
     }
 
     func parsePathSegments(_ data: String) throws -> [Segment] {
-        guard !data.isEmpty else { return [] }
-
         var segments = Array<Segment>()
 
         var scanner = PathScanner(string: data)
 
         scanner.charactersToBeSkipped = Foundation.CharacterSet.whitespacesAndNewlines
+
+        guard !scanner.isAtEnd else {
+            return []
+        }
 
         var lastCommand: Command?
 

--- a/DOM/Tests/Parser.XML.PathTests.swift
+++ b/DOM/Tests/Parser.XML.PathTests.swift
@@ -67,7 +67,13 @@ final class ParserXMLPathTests: XCTestCase {
     XCTAssertNotEqual(Segment.move(x: 10, y: 20, space: .relative),
                       move(10, 20, .absolute))
   }
-  
+
+  func testEmpty() throws {
+    let parser = SwiftDrawDOM.XMLParser()
+    XCTAssertEqual(try parser.parsePathSegments(""), [])
+    XCTAssertEqual(try parser.parsePathSegments("       "), [])
+  }
+
   func testMove() {
     AssertSegmentEquals("M 10 20", move(10, 20, .absolute))
     AssertSegmentEquals("m 10 20", move(10, 20, .relative))


### PR DESCRIPTION
Adds tests to cover logic added in https://github.com/swhitty/SwiftDraw/pull/84

extends logic to also handle paths that are just whitespace