### PR TITLE
align SFSymbols left and right to the guides

### DIFF
--- a/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
+++ b/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
@@ -65,7 +65,7 @@ final class RendererSFSymbolTests: XCTestCase {
         )
 
         XCTAssertTrue(
-            template.regular.bounds.size.width == 108.0
+            template.regular.bounds.size.width == 88.0
         )
         XCTAssertTrue(
             template.regular.bounds.size.height == 70.0


### PR DESCRIPTION
Updates the alignment of SFSymbols and left/right guides to precisely align to the supplied insets.

When `--insets auto` is used the left/right guides are placed 10pt from the detected paths which is similar to how many official symbols are aligned;

<img width="178" height="194" alt="chevron-left" src="https://github.com/user-attachments/assets/fa12d9c2-ce44-4a91-bdbc-ba5bddf9a735" />
<img width="167" height="180" alt="arrow circle" src="https://github.com/user-attachments/assets/12fff787-bc84-46cb-a093-b8a99e07cab3" />

When a single `--insets` are supplied, these insets are now automatically used for all variants;
```
% swiftdraw image.svg --format sfsymbol --insets 10 20 10 20
Alignment: --insets 10 20 10 20
Alignment: --ultralightInsets 10 20 10 20
Alignment: --blackInsets 10 20 10 20
```

