### PR TITLE
--legacy option

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -94,6 +94,7 @@ Available keys for --format sfsymbol:
  --ultralightInsets   alignment of ultralight variant: top,left,bottom,right | auto
  --black              svg file of black variant
  --blackInsets        alignment of black variant: top,left,bottom,right | auto
+ --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
 
 
 """)

--- a/DOM/Sources/Parser.XML.swift
+++ b/DOM/Sources/Parser.XML.swift
@@ -49,8 +49,8 @@ package struct XMLParser {
             self.rawValue = rawValue
         }
 
-        package static let skipInvalidAttributes = Options(rawValue: 1)
-        package static let skipInvalidElements = Options(rawValue: 2)
+        package static let skipInvalidAttributes = Options(rawValue: 1 << 0)
+        package static let skipInvalidElements = Options(rawValue: 1 << 1)
     }
 
     package init(options: Options = [], filename: String? = nil) {

--- a/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
@@ -51,14 +51,19 @@ public extension CommandLine {
                                                  precision: config.precision ?? 2)
             return code.data(using: .utf8)!
         case .sfsymbol:
-            let renderer = SFSymbolRenderer(options: config.options,
-                                            insets: config.insets,
-                                            insetsUltralight: config.insetsUltralight ?? config.insets,
-                                            insetsBlack: config.insetsBlack ?? config.insets,
-                                            precision: config.precision ?? 3)
-            let svg = try renderer.render(regular: config.input,
-                                          ultralight: config.inputUltralight,
-                                          black: config.inputBlack)
+            let renderer = SFSymbolRenderer(
+                options: config.options,
+                insets: config.insets,
+                insetsUltralight: config.insetsUltralight ?? config.insets,
+                insetsBlack: config.insetsBlack ?? config.insets,
+                precision: config.precision ?? 3,
+                isLegacyInsets: config.isLegacyInsetsEnabled
+            )
+            let svg = try renderer.render(
+                regular: config.input,
+                ultralight: config.inputUltralight,
+                black: config.inputBlack
+            )
             return svg.data(using: .utf8)!
         case .jpeg, .pdf, .png:
             #if canImport(CoreGraphics)

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
@@ -46,9 +46,15 @@ extension CommandLine {
         case black
         case blackInsets
         case hideUnsupportedFilters
+        case legacy
 
         var hasValue: Bool {
-            self != .hideUnsupportedFilters
+            switch self {
+            case .hideUnsupportedFilters, .legacy:
+                return false
+            default:
+                return true
+            }
         }
     }
 

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
@@ -48,6 +48,7 @@ extension CommandLine {
         public var scale: Scale
         public var options: SVG.Options
         public var precision: Int?
+        public var isLegacyInsetsEnabled: Bool
     }
 
     public enum Format: String {
@@ -119,19 +120,22 @@ extension CommandLine {
 
         let options = try parseOptions(from: modifiers)
         let result = source.newURL(for: format, scale: scale)
-        return Configuration(input: source,
-                             inputUltralight: ultralight,
-                             inputBlack: black,
-                             output: output ?? result,
-                             format: format,
-                             size: size,
-                             api: api,
-                             insets: insets,
-                             insetsUltralight: ultralightInsets,
-                             insetsBlack: blackInsets,
-                             scale: scale,
-                             options: options,
-                             precision: precision)
+        return Configuration(
+            input: source,
+            inputUltralight: ultralight,
+            inputBlack: black,
+            output: output ?? result,
+            format: format,
+            size: size,
+            api: api,
+            insets: insets,
+            insetsUltralight: ultralightInsets,
+            insetsBlack: blackInsets,
+            scale: scale,
+            options: options,
+            precision: precision,
+            isLegacyInsetsEnabled: modifiers.keys.contains(.legacy)
+        )
     }
 
     static func parseFileURL(file: String, within directory: URL) throws -> URL {

--- a/SwiftDraw/Sources/LayerTree/LayerTree.CommandOptimizer.swift
+++ b/SwiftDraw/Sources/LayerTree/LayerTree.CommandOptimizer.swift
@@ -144,8 +144,8 @@ struct OptimizerOptions: OptionSet {
         self.rawValue = rawValue
     }
 
-    static let skipRedundantState = OptimizerOptions(rawValue: 1)
-    static let skipInitialSaveState = OptimizerOptions(rawValue: 2)
+    static let skipRedundantState = OptimizerOptions(rawValue: 1 << 0)
+    static let skipInitialSaveState = OptimizerOptions(rawValue: 1 << 1)
 }
 
 extension RendererCommand {

--- a/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
+++ b/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
@@ -187,18 +187,26 @@ private extension DOM.SVG {
 private extension SFSymbolRenderer {
 
     static func render(fileURL: URL) throws -> String {
-        let renderer = SFSymbolRenderer(options: [], insets: .init(),
-                                        insetsUltralight: .init(),
-                                        insetsBlack: .init(),
-                                        precision: 3)
+        let renderer = SFSymbolRenderer(
+            options: [],
+            insets: .init(),
+            insetsUltralight: .init(),
+            insetsBlack: .init(),
+            precision: 3,
+            isLegacyInsets: false
+        )
         return try renderer.render(regular: fileURL, ultralight: nil, black: nil)
     }
 
     static func render(svg: DOM.SVG) throws -> String {
-        let renderer = SFSymbolRenderer(options: [], insets: .init(),
-                                        insetsUltralight: .init(),
-                                        insetsBlack: .init(),
-                                        precision: 3)
+        let renderer = SFSymbolRenderer(
+            options: [],
+            insets: .init(),
+            insetsUltralight: .init(),
+            insetsBlack: .init(),
+            precision: 3,
+            isLegacyInsets: false
+        )
         return try renderer.render(default: svg, ultralight: nil, black: nil)
     }
 }


### PR DESCRIPTION
The SFSymbol alignment logic was updated within https://github.com/swhitty/SwiftDraw/pull/88 to be more precise and similar to the alignment of official SFSymbols:

<img width="91" height="167" alt="updated" src="https://github.com/user-attachments/assets/802c39a1-179d-4b99-ad27-30f227c1dd68" />

This change may be unexpected for some users so this PR adds the `--legacy` option to preserve the alignment from previous version

```
--legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
```

<img width="140" height="189" alt="legacy" src="https://github.com/user-attachments/assets/873b70be-c794-487c-b6fb-ace6d14b93ca" />
