### PR TITLE
Kebab case

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -68,7 +68,7 @@ extension SwiftDraw.CommandLine {
     static func printHelp() {
         print("")
         print("""
-swiftdraw, version 0.22.0
+swiftdraw, version 0.23.0
 copyright (c) 2025 Simon Whitty
 
 usage: swiftdraw <file.svg> [--format png | pdf | jpeg | swift | sfsymbol] [--size wxh] [--scale 1x | 2x | 3x]

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -83,7 +83,7 @@ Options:
  --precision   maximum number of decimal places
  --output      optional path of output file
 
- --hideUnsupportedFilters   hide elements with unsupported filters.
+ --hide-unsupported-filters   hide elements with unsupported filters.
 
 Available keys for --format swift:
  --api                api of generated code:  appkit | uikit
@@ -91,9 +91,9 @@ Available keys for --format swift:
 Available keys for --format sfsymbol:
  --insets             alignment of regular variant: top,left,bottom,right | auto
  --ultralight         svg file of ultralight variant
- --ultralightInsets   alignment of ultralight variant: top,left,bottom,right | auto
+ --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
  --black              svg file of black variant
- --blackInsets        alignment of black variant: top,left,bottom,right | auto
+ --black-insets       alignment of black variant: top,left,bottom,right | auto
  --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
 
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options:
  --precision   maximum number of decimal places
  --output      optional path of output file
 
- --hideUnsupportedFilters   hide elements with unsupported filters.
+ --hide-unsupported-filters   hide elements with unsupported filters.
 
 Available keys for --format swift:
  --api                api of generated code:  appkit | uikit
@@ -103,9 +103,10 @@ Available keys for --format swift:
 Available keys for --format sfsymbol:
  --insets             alignment of regular variant: top,left,bottom,right | auto
  --ultralight         svg file of ultralight variant
- --ultralightInsets   alignment of ultralight variant: top,left,bottom,right | auto
+ --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
  --black              svg file of black variant
- --blackInsets        alignment of black variant: top,left,bottom,right | auto
+ --black-insets       alignment of black variant: top,left,bottom,right | auto
+ --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
 ```
 
 ```bash

--- a/SwiftDraw.podspec.json
+++ b/SwiftDraw.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftDraw",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "summary": "A Swift library that adds support for SVG files to UIImage and NSImage.",
   "homepage": "https://github.com/swhitty/SwiftDraw",
   "authors": "Simon Whitty",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/swhitty/SwiftDraw.git",
-    "tag": "0.22.0"
+    "tag": "0.23.0"
   },
   "platforms": {
     "ios": "13.0",
@@ -45,6 +45,6 @@
     "OTHER_SWIFT_FLAGS": "-package-name SwiftDraw"
   },
   "dependencies": {
-    "SwiftDrawDOM": "~> 0.22.0"
+    "SwiftDrawDOM": "~> 0.23.0"
   }
 }

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
@@ -56,6 +56,23 @@ extension CommandLine {
                 return true
             }
         }
+
+        static func make(from text: String) -> Self? {
+            if let modifier = Modifier(rawValue: text) {
+                return modifier
+            }
+
+            switch text {
+            case "ultralight-insets":
+                return .ultralightInsets
+            case "black-insets":
+                return .blackInsets
+            case "hide-unsupported-filters":
+                return .hideUnsupportedFilters
+            default:
+                return nil
+            }
+        }
     }
 
     static func parseModifiers(from args: [String]) throws -> [Modifier: String?] {
@@ -91,7 +108,7 @@ private extension Array where Element == String {
         }
 
         guard self[0].hasPrefix("--"),
-              let modifier = CommandLine.Modifier(rawValue: String(self[0].dropFirst(2))) else {
+              let modifier = CommandLine.Modifier.make(from: String(self[0].dropFirst(2))) else {
             throw CommandLine.Error.invalid
         }
 

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
@@ -110,7 +110,7 @@ extension CommandLine {
         let size = try parseSize(from: modifiers[.size])
         let scale = try parseScale(from: modifiers[.scale])
         let precision = try parsePrecision(from: modifiers[.precision])
-        let insets = try parseInsets(from: modifiers[.insets])
+        let insets = try parseInsets(from: modifiers[.insets]) ?? Insets()
         let api = try parseAPI(from: modifiers[.api])
         let ultralight = try parseFileURL(file: modifiers[.ultralight], within: baseDirectory)
         let ultralightInsets = try parseInsets(from: modifiers[.ultralightInsets])
@@ -208,11 +208,11 @@ extension CommandLine {
         return api
     }
 
-    static func parseInsets(from value: String??) throws -> Insets {
+    static func parseInsets(from value: String??) throws -> Insets? {
         guard let value = value,
               let value = value,
               value != "auto" else {
-            return Insets()
+            return nil
         }
 
         var scanner = XMLParser.Scanner(text: value)

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
@@ -210,9 +210,12 @@ extension CommandLine {
 
     static func parseInsets(from value: String??) throws -> Insets? {
         guard let value = value,
-              let value = value,
-              value != "auto" else {
+              let value = value else {
             return nil
+        }
+
+        guard value != "auto" else {
+            return Insets()
         }
 
         var scanner = XMLParser.Scanner(text: value)

--- a/SwiftDraw/Sources/Renderer/Renderer.SFSymbol.swift
+++ b/SwiftDraw/Sources/Renderer/Renderer.SFSymbol.swift
@@ -144,7 +144,7 @@ extension SFSymbolRenderer {
     }
 
     func makeBounds(svg: DOM.SVG, isRegularSVG: Bool = true, auto: LayerTree.Rect, for variant: Variant) throws -> LayerTree.Rect {
-        let insets = getInsets(for: isRegularSVG ? .regular : variant)
+        let insets = getInsets(for: variant)
         let width = LayerTree.Float(svg.width)
         let height = LayerTree.Float(svg.height)
         let top = insets.top ?? Double(auto.minY)
@@ -337,9 +337,9 @@ extension SFSymbolRenderer {
         case .regular:
             print("Alignment: --insets \(top),\(left),\(bottom),\(right)")
         case .ultralight:
-            print("Alignment: --ultralightInsets \(top),\(left),\(bottom),\(right)")
+            print("Alignment: --ultralight-insets \(top),\(left),\(bottom),\(right)")
         case .black:
-            print("Alignment: --blackInsets \(top),\(left),\(bottom),\(right)")
+            print("Alignment: --black-insets \(top),\(left),\(bottom),\(right)")
         }
     }
 

--- a/SwiftDraw/Tests/CommandLine/CommandLine.ArgumentsTests.swift
+++ b/SwiftDraw/Tests/CommandLine/CommandLine.ArgumentsTests.swift
@@ -34,29 +34,36 @@ import XCTest
 
 final class CommandLineArgumentsTests: XCTestCase {
 
-  func testParseModifiers() throws {
-    let modifiers = try CommandLine.parseModifiers(from: ["--format", "some", "--output", "more", "--scale", "magnify", "--size", "huge"])
-    XCTAssertEqual(modifiers, [.format: "some", .output: "more", .scale: "magnify", .size: "huge"])
-  }
+    func testParseModifiers() throws {
+        var modifiers = try CommandLine.parseModifiers(from: ["--format", "some", "--output", "more", "--scale", "magnify", "--size", "huge"])
+        XCTAssertEqual(modifiers, [.format: "some", .output: "more", .scale: "magnify", .size: "huge"])
 
-  func testParseModifiersThrowsForOddPairs() {
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format"]))
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--output"]))
-  }
+        modifiers = try CommandLine.parseModifiers(from: ["--ultralightInsets", "a", "--blackInsets", "b", "--hideUnsupportedFilters", "--legacy"])
+        XCTAssertEqual(modifiers, [.ultralightInsets: "a", .blackInsets: "b", .hideUnsupportedFilters: nil, .legacy: nil])
 
-  func testParseModifiersThrowsForDuplicateModifiers() {
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--format", "jpg"]))
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from:  ["--format", "png", "--output", "more", "--output", "evenmore"]))
-  }
+        modifiers = try CommandLine.parseModifiers(from: ["--ultralight-insets", "a", "--black-insets", "b", "--hide-unsupported-filters", "--legacy"])
+        XCTAssertEqual(modifiers, [.ultralightInsets: "a", .blackInsets: "b", .hideUnsupportedFilters: nil, .legacy: nil])"
 
-  func testParseModifiersThrowsForUnknownModifiers() {
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--unknown", "png"]))
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--unknown", "more"]))
-  }
+    }
 
-  func testParseModifiersThrowsForMissingPrefix() {
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["format", "png"]))
-    XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "output", "more"]))
-  }
+    func testParseModifiersThrowsForOddPairs() {
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format"]))
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--output"]))
+    }
+
+    func testParseModifiersThrowsForDuplicateModifiers() {
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--format", "jpg"]))
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from:  ["--format", "png", "--output", "more", "--output", "evenmore"]))
+    }
+
+    func testParseModifiersThrowsForUnknownModifiers() {
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--unknown", "png"]))
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "--unknown", "more"]))
+    }
+
+    func testParseModifiersThrowsForMissingPrefix() {
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["format", "png"]))
+        XCTAssertThrowsError(try CommandLine.parseModifiers(from: ["--format", "png", "output", "more"]))
+    }
 
 }

--- a/SwiftDraw/Tests/CommandLine/CommandLine.ArgumentsTests.swift
+++ b/SwiftDraw/Tests/CommandLine/CommandLine.ArgumentsTests.swift
@@ -42,7 +42,7 @@ final class CommandLineArgumentsTests: XCTestCase {
         XCTAssertEqual(modifiers, [.ultralightInsets: "a", .blackInsets: "b", .hideUnsupportedFilters: nil, .legacy: nil])
 
         modifiers = try CommandLine.parseModifiers(from: ["--ultralight-insets", "a", "--black-insets", "b", "--hide-unsupported-filters", "--legacy"])
-        XCTAssertEqual(modifiers, [.ultralightInsets: "a", .blackInsets: "b", .hideUnsupportedFilters: nil, .legacy: nil])"
+        XCTAssertEqual(modifiers, [.ultralightInsets: "a", .blackInsets: "b", .hideUnsupportedFilters: nil, .legacy: nil])
 
     }
 

--- a/SwiftDraw/Tests/CommandLine/CommandLine.ConfigurationTests.swift
+++ b/SwiftDraw/Tests/CommandLine/CommandLine.ConfigurationTests.swift
@@ -90,9 +90,8 @@ final class CommandLineConfigurationTests: XCTestCase {
     }
 
     func testParseInsets() throws {
-        XCTAssertEqual(
-            try CommandLine.parseInsets(from: nil),
-            .init()
+        XCTAssertNil(
+            try CommandLine.parseInsets(from: nil)
         )
         XCTAssertEqual(
             try CommandLine.parseInsets(from: "auto"),

--- a/SwiftDrawDOM.podspec.json
+++ b/SwiftDrawDOM.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftDrawDOM",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "summary": "A Swift library that adds support for SVG files to UIImage and NSImage.",
   "homepage": "https://github.com/swhitty/SwiftDraw",
   "authors": "Simon Whitty",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/swhitty/SwiftDraw.git",
-    "tag": "0.22.0"
+    "tag": "0.23.0"
   },
   "platforms": {
     "ios": "13.0",


### PR DESCRIPTION
Updates the command line options to use `kebab-case` for the following options
- `--hide-unsupported-filters`
- `--ultralight-insets`
- `--black-insets`

```
swiftdraw, version 0.23.0
copyright (c) 2025 Simon Whitty

usage: swiftdraw <file.svg> [--format png | pdf | jpeg | swift | sfsymbol] [--size wxh] [--scale 1x | 2x | 3x]

<file> svg file to be processed

Options:
 --format      format to output image: png | pdf | jpeg | swift | sfsymbol
 --size        size of output image: 100x200
 --scale       scale of output image: 1x | 2x | 3x
 --insets      crop inset of output image: top,left,bottom,right
 --precision   maximum number of decimal places
 --output      optional path of output file

 --hide-unsupported-filters   hide elements with unsupported filters.

Available keys for --format swift:
 --api                api of generated code:  appkit | uikit

Available keys for --format sfsymbol:
 --insets             alignment of regular variant: top,left,bottom,right | auto
 --ultralight         svg file of ultralight variant
 --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
 --black              svg file of black variant
 --black-insets       alignment of black variant: top,left,bottom,right | auto
 --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
```

For compatibility with existing scripts the previous camelCase names are also still valid:
- `--hideUnsupportedFilters`
- `--ultralightInsets`
- `--blackInsets`

