### PR TITLE
support small, medium and large SFSymbols

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -90,6 +90,7 @@ Available keys for --format swift:
 
 Available keys for --format sfsymbol:
  --insets             alignment of regular variant: top,left,bottom,right | auto
+ --size               size category to generate: small, medium large. (default is small)
  --ultralight         svg file of ultralight variant
  --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
  --black              svg file of black variant

--- a/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
@@ -52,6 +52,7 @@ public extension CommandLine {
             return code.data(using: .utf8)!
         case .sfsymbol:
             let renderer = SFSymbolRenderer(
+                size: config.symbolSize ?? .small,
                 options: config.options,
                 insets: config.insets,
                 insetsUltralight: config.insetsUltralight ?? config.insets,

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
@@ -48,6 +48,7 @@ extension CommandLine {
         public var scale: Scale
         public var options: SVG.Options
         public var precision: Int?
+        public var symbolSize: SFSymbolRenderer.SizeCategory?
         public var isLegacyInsetsEnabled: Bool
     }
 
@@ -107,7 +108,7 @@ extension CommandLine {
             throw Error.invalid
         }
 
-        let size = try parseSize(from: modifiers[.size])
+        let size = try parseSize(from: modifiers[.size], format: format)
         let scale = try parseScale(from: modifiers[.scale])
         let precision = try parsePrecision(from: modifiers[.precision])
         let insets = try parseInsets(from: modifiers[.insets]) ?? Insets()
@@ -117,6 +118,7 @@ extension CommandLine {
         let black = try parseFileURL(file: modifiers[.black], within: baseDirectory)
         let blackInsets = try parseInsets(from: modifiers[.blackInsets])
         let output = try parseFileURL(file: modifiers[.output], within: baseDirectory)
+        let symbolSize = try parseSymbolSize(from: modifiers[.size], format: format)
 
         let options = try parseOptions(from: modifiers)
         let result = source.newURL(for: format, scale: scale)
@@ -134,6 +136,7 @@ extension CommandLine {
             scale: scale,
             options: options,
             precision: precision,
+            symbolSize: symbolSize,
             isLegacyInsetsEnabled: modifiers.keys.contains(.legacy)
         )
     }
@@ -178,8 +181,9 @@ extension CommandLine {
         return precision
     }
 
-    static func parseSize(from value: String??) throws -> Size {
-        guard let value = value,
+    static func parseSize(from value: String??, format: Format) throws -> Size {
+        guard format != .sfsymbol,
+              let value = value,
               let value = value else {
             return .default
         }
@@ -194,6 +198,26 @@ extension CommandLine {
         }
 
         return .custom(width: Int(width), height: Int(height))
+    }
+
+    static func parseSymbolSize(from value: String??, format: Format) throws -> SFSymbolRenderer.SizeCategory? {
+        guard format == .sfsymbol,
+              let value = value,
+              let value = value else {
+            return nil
+        }
+
+        switch value {
+        case "small":
+            return .small
+        case "medium":
+            return .medium
+        case "large":
+            return .large
+        default:
+            throw Error.invalid
+
+        }
     }
 
     static func parseAPI(from value: String??) throws -> API? {

--- a/SwiftDraw/Sources/Formatter/XML.Formatter.SVG.swift
+++ b/SwiftDraw/Sources/Formatter/XML.Formatter.SVG.swift
@@ -328,17 +328,17 @@ extension XML.Formatter {
             case let .matrix(a: a, b: b, c: c, d: d, e: e, f: f):
                 return "matrix(\(formatter.format(a,b,c,d,e,f)))"
             case let .translate(tx: tx, ty: ty):
-                return "translate(\(formatter.format(tx, ty))"
+                return "translate(\(formatter.format(tx, ty)))"
             case let .scale(sx: sx, sy: sy):
-                return "scale(\(formatter.format(sx, sy))"
+                return "scale(\(formatter.format(sx, sy)))"
             case let .rotate(angle: angle):
-                return "rotate(\(formatter.format(angle))"
+                return "rotate(\(formatter.format(angle)))"
             case let .rotatePoint(angle: angle, cx: cx, cy: cy):
-                return "rotate(\(formatter.format(angle, cx, cy))"
+                return "rotate(\(formatter.format(angle, cx, cy)))"
             case let .skewX(angle: angle):
-                return "skewX(\(formatter.format(angle))"
+                return "skewX(\(formatter.format(angle)))"
             case let .skewY(angle: angle):
-                return "skewY(\(formatter.format(angle))"
+                return "skewY(\(formatter.format(angle)))"
             }
         }
 

--- a/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
+++ b/SwiftDraw/Tests/Renderer/Renderer.SFSymbolTests.swift
@@ -188,6 +188,7 @@ private extension SFSymbolRenderer {
 
     static func render(fileURL: URL) throws -> String {
         let renderer = SFSymbolRenderer(
+            size: .small,
             options: [],
             insets: .init(),
             insetsUltralight: .init(),
@@ -200,6 +201,7 @@ private extension SFSymbolRenderer {
 
     static func render(svg: DOM.SVG) throws -> String {
         let renderer = SFSymbolRenderer(
+            size: .small,
             options: [],
             insets: .init(),
             insetsUltralight: .init(),


### PR DESCRIPTION
Currently SwiftDraw generates SFSymbols in the small size category.  This PR allows users to generate symbols in either small, medium or large;

```
% swiftdraw arrow-circle.svg --format sfsymbol --size medium
```

<img width="794" height="593" alt="medium" src="https://github.com/user-attachments/assets/c607114f-3152-4a4f-bca2-87de8a78d7f5" />

```
Available keys for --format sfsymbol:
 --insets             alignment of regular variant: top,left,bottom,right | auto
 --size               size category to generate: small, medium large. (default is small)
 --ultralight         svg file of ultralight variant
 --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
 --black              svg file of black variant
 --black-insets       alignment of black variant: top,left,bottom,right | auto
 --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
```