### PR TITLE
SVGCache

### DIFF
--- a/Examples/Sources/GalleryView.swift
+++ b/Examples/Sources/GalleryView.swift
@@ -34,37 +34,33 @@ import SwiftUI
 
 struct GalleryView: View {
 
-    var images: [SVG] = {
-        [
-            "thats-no-moon.svg",
-            "avocado.svg",
-            "angry.svg",
-            "ogre.svg",
-            "monkey.svg",
-            "fuji.svg",
-            "dish.svg",
-            "mouth-open.svg",
-            "sleepy.svg",
-            "smile.svg",
-            "snake.svg",
-            "spider.svg",
-            "star-struck.svg",
-            "worried.svg",
-            "yawning.svg",
-            "thats-no-moon.svg",
-            "alert.svg",
-            "effigy.svg",
-            "stylesheet-multiple.svg"
-        ].compactMap {
-            SVG(named: $0, in: .samples)
-        }
-    }()
+    var images = [
+        "thats-no-moon.svg",
+        "avocado.svg",
+        "angry.svg",
+        "ogre.svg",
+        "monkey.svg",
+        "fuji.svg",
+        "dish.svg",
+        "mouth-open.svg",
+        "sleepy.svg",
+        "smile.svg",
+        "snake.svg",
+        "spider.svg",
+        "star-struck.svg",
+        "worried.svg",
+        "yawning.svg",
+        "thats-no-moon.svg",
+        "alert.svg",
+        "effigy.svg",
+        "stylesheet-multiple.svg"
+    ]
 
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 20) {
                 ForEach(images, id: \.self) { image in
-                    SVGView(svg: image)
+                    SVGView(image, bundle: .samples)
                         .aspectRatio(contentMode: .fit)
                         .padding([.leading, .trailing], 10)
                 }

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ Display an image within `SVGView`:
 
 ```swift
 var body: some View {
-    SVGView(named: "sample.svg")
+    SVGView("sample.svg")
         .aspectRatio(contentMode: .fit)
         .padding()
 }
 ```
 
-Pass an `SVG` instance for better performance:
+When you load by name, SVGView uses an internal cache so repeated lookups are efficient.
+For more predictable performance (avoiding any cache lookup or parsing), you can pass an already-created SVG instance:
 
 ```swift
 var image: SVG

--- a/SwiftDraw/Sources/Renderer/Renderer.CoreGraphics+Cost.swift
+++ b/SwiftDraw/Sources/Renderer/Renderer.CoreGraphics+Cost.swift
@@ -1,0 +1,119 @@
+//
+//  Renderer.CoreGraphics+Cost.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 31/8/25.
+//  Copyright 2025 WhileLoop Pty Ltd. All rights reserved.
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+extension [RendererCommand<CGTypes>] {
+
+    var estimatedCost: Int {
+        let commandCost = MemoryLayout<Self>.stride * count
+        let pathCost = Set(allPaths).reduce(0) { $0 + $1.estimatedCost }
+        let imageCost = Set(allImages).reduce(0) { $0 + $1.estimatedCost }
+        return commandCost + pathCost + imageCost
+    }
+}
+
+extension CGPath {
+
+    var estimatedCost: Int {
+        var total = 0
+        applyWithBlock { element in
+            switch element.pointee.type {
+            case .moveToPoint, .addLineToPoint, .closeSubpath:
+                total += MemoryLayout<CGPathElement>.stride + MemoryLayout<CGPoint>.stride
+            case .addQuadCurveToPoint:
+                total += MemoryLayout<CGPathElement>.stride + 2 * MemoryLayout<CGPoint>.stride
+            case .addCurveToPoint:
+                total += MemoryLayout<CGPathElement>.stride + 3 * MemoryLayout<CGPoint>.stride
+            @unknown default:
+                break
+            }
+        }
+        return MemoryLayout<CGPath>.size + total
+    }
+}
+
+extension CGImage {
+    var estimatedCost: Int { bytesPerRow * height }
+}
+
+extension RendererCommand<CGTypes> {
+
+    var allPaths: [CGPath] {
+        switch self {
+        case .setClip(path: let p, rule: _):
+            return [p]
+        case .setFillPattern(let p):
+            return p.contents.allPaths
+        case .stroke(let p):
+            return [p]
+        case .clipStrokeOutline(let p):
+            return [p]
+        case .fill(let p, rule: _):
+            return [p]
+        default:
+            return []
+        }
+    }
+
+    var allImages: [CGImage] {
+        switch self {
+        case .setFillPattern(let p):
+            return p.contents.allImages
+        case .draw(image: let i, in: _):
+            return [i]
+        default:
+            return []
+        }
+    }
+}
+
+extension [RendererCommand<CGTypes>] {
+
+    var allPaths: [CGPath] {
+        var paths = [CGPath]()
+        for command in self {
+            paths.append(contentsOf: command.allPaths)
+        }
+        return paths
+    }
+
+    var allImages: [CGImage] {
+        var images = [CGImage]()
+        for command in self {
+            images.append(contentsOf: command.allImages)
+        }
+        return images
+    }
+}
+
+#endif

--- a/SwiftDraw/Sources/Renderer/Renderer.CoreGraphics.swift
+++ b/SwiftDraw/Sources/Renderer/Renderer.CoreGraphics.swift
@@ -59,8 +59,8 @@ struct CGTypes: RendererTypes, Sendable {
 
 struct CGTransformingPattern: Hashable {
 
-    let bounds: CGRect
-    let contents: [RendererCommand<CGTypes>]
+    var bounds: CGRect
+    var contents: [RendererCommand<CGTypes>]
 
     init(bounds: CGRect, contents: [RendererCommand<CGTypes>]) {
         self.bounds = bounds

--- a/SwiftDraw/Sources/SVG.swift
+++ b/SwiftDraw/Sources/SVG.swift
@@ -47,12 +47,17 @@ public struct SVG: Hashable, Sendable {
     var commands: [RendererCommand<CGTypes>]
 
     public init?(fileURL url: URL, options: SVG.Options = .default) {
-        do {
-            let svg = try DOM.SVG.parse(fileURL: url)
-            self.init(dom: svg, options: options)
-        } catch {
-            XMLParser.logParsingError(for: error, filename: url.lastPathComponent, parsing: nil)
-            return nil
+        if let svg = SVGGCache.shared.svg(fileURL: url) {
+            self = svg
+        } else {
+            do {
+                let svg = try DOM.SVG.parse(fileURL: url)
+                self.init(dom: svg, options: options)
+                SVGGCache.shared.setSVG(self, for: url)
+            } catch {
+                XMLParser.logParsingError(for: error, filename: url.lastPathComponent, parsing: nil)
+                return nil
+            }
         }
     }
 

--- a/SwiftDraw/Sources/SVGCache.swift
+++ b/SwiftDraw/Sources/SVGCache.swift
@@ -1,0 +1,75 @@
+//
+//  SVG.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 24/5/17.
+//  Copyright 2020 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import SwiftDrawDOM
+public import Foundation
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+public final class SVGGCache: Sendable {
+
+    public static let shared = SVGGCache()
+
+    nonisolated(unsafe)private let cache: NSCache<NSURL, Box<SVG>>
+
+    public init(totalCostLimit: Int = defaultTotalCostLimit) {
+        self.cache = NSCache()
+        self.cache.totalCostLimit = totalCostLimit
+    }
+
+    public func svg(fileURL: URL) -> SVG? {
+        cache.object(forKey: fileURL as NSURL)?.value
+    }
+
+    public func setSVG(_ svg: SVG, for fileURL: URL) {
+        cache.setObject(Box(svg), forKey: fileURL as NSURL, cost: svg.commands.estimatedCost)
+    }
+
+    final class Box<T: Hashable>: NSObject {
+        let value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    public static var defaultTotalCostLimit: Int {
+    #if canImport(WatchKit)
+        // 2 MB
+        return 2 * 1024 * 1024
+    #elseif canImport(AppKit)
+        // 200 MB
+        return 200 * 1024 * 1024
+    #else
+        // 50 MB
+        return 50 * 1024 * 1024
+    #endif
+    }
+}
+#endif

--- a/SwiftDraw/Tests/Renderer/Renderer.CoreGraphics+CostTests.swift
+++ b/SwiftDraw/Tests/Renderer/Renderer.CoreGraphics+CostTests.swift
@@ -1,0 +1,108 @@
+//
+//  Renderer.CoreGraphics+CostTests.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 31/8/25.
+//  Copyright 2025 WhileLoop Pty Ltd. All rights reserved.
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import Foundation
+@testable import SwiftDraw
+import SwiftDrawDOM
+import Testing
+
+struct RendererCoreGraphicsCostTests {
+
+    @Test
+    func duplicatePathInstancesRemoved() throws {
+        let source = try SVG.fromXML(#"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <clipPath id="cp1">
+                <rect width="30" height="30" />
+            </clipPath>
+            <rect width="30" height="30" fill="red" stroke="blue" />
+            <rect width="30" height="30" fill="pink" stroke="yellow" clip-path="url(#cp1)"/>
+        </svg>
+        """#)
+
+        let uniquePaths = Set(source.commands.allPaths.map(ObjectIdentifier.init))
+        #expect(uniquePaths.count == 1)
+    }
+
+    @Test
+    func duplicateImageInstancesRemoved() throws {
+        let source = try SVG.fromXML(#"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <image id="dot" width="6" height="6" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" />
+            <image id="dot" width="6" height="6" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" />
+        </svg>
+        """#)
+
+        let uniqueImages = Set(source.commands.allImages.map(ObjectIdentifier.init))
+        #expect(uniqueImages.count == 1)
+    }
+
+    @Test
+    func pathEstimatedCost() throws {
+        let source = try SVG.fromXML(#"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <rect width="30" height="30" fill="red" stroke="blue" />
+        </svg>
+        """#)
+
+        #expect(source.commands.allPaths[0].estimatedCost == 168)
+        #expect(source.commands.estimatedCost == 232)
+    }
+
+    @Test
+    func imageEstimatedCost() throws {
+        let source = try SVG.fromXML(#"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <image id="dot" width="6" height="6" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" />
+        </svg>
+        """#)
+
+        #expect(source.commands.allImages[0].estimatedCost == 100)
+        #expect(source.commands.estimatedCost == 108)
+    }
+
+    @Test
+    func shapesEstimatedCost() throws {
+        let image = try #require(SVG(named: "shapes.svg", in: .test))
+        #expect(image.commands.estimatedCost == 19220)
+    }
+}
+
+extension SVG {
+    static func fromXML(_ text: String, filename: String = #file) throws -> SVG {
+        let dom = try DOM.SVG.parse(data: text.data(using: .utf8)!)
+        return SVG(dom: dom, options: .default)
+    }
+}
+#endif


### PR DESCRIPTION
Adds `SVGCache` which is used to cache parsed SVG instances from disk.

When using `SVG` or `SVGView` with images stored on the disk, instances are now stored within a `NSCache` so subsequent reloads are near instant and do not need to parse the file into a DOM and create the render commands.

Below all 3 views draw the same SVG but it is only parsed and process once;

```swift
VStack {
   SVGView("sample.svg")
   SVGView("sample.svg")
   SVGView("sample.svg")
}
```