### PR TITLE
SVGView.resizable()

### DIFF
--- a/Examples/Sources/GalleryView.swift
+++ b/Examples/Sources/GalleryView.swift
@@ -61,7 +61,8 @@ struct GalleryView: View {
             LazyVStack(spacing: 20) {
                 ForEach(images, id: \.self) { image in
                     SVGView(image, bundle: .samples)
-                        .aspectRatio(contentMode: .fit)
+                        .resizable()
+                        .scaledToFit()
                         .padding([.leading, .trailing], 10)
                 }
             }

--- a/README.md
+++ b/README.md
@@ -38,15 +38,21 @@ imageView.image = svg.rasterize()   // 240x200
 
 ### SwiftUI
 
-Display an image within `SVGView`:
+SVGs can be displayed within `SVGView` just like using SwiftUI's built-in `Image`:
 
 ```swift
-var body: some View {
-    SVGView("sample.svg")
-        .aspectRatio(contentMode: .fit)
-        .padding()
-}
+SVGView("sample.svg")
 ```
+
+By default, SVGs are rendered at their original (intrinsic) size. To make them flexible within layouts, mark them as resizable — exactly like `Image`:    
+
+```swift
+SVGView("sample.svg")
+   .resizable()
+   .scaledToFit()
+```
+
+This allows the SVG to scale proportionally to fit within its container.  Use `.scaledToFill()` to completely cover the container and use `.resizable(resizingMode: .tile)` to draw the SVG in repeating tiles filling the available space.
 
 When you load by name, SVGView uses an internal cache so repeated lookups are efficient.
 For more predictable performance (avoiding any cache lookup or parsing), you can pass an already-created SVG instance:

--- a/SwiftDraw/Sources/SVG+CoreGraphics.swift
+++ b/SwiftDraw/Sources/SVG+CoreGraphics.swift
@@ -35,21 +35,43 @@ public import Foundation
 
 public extension CGContext {
 
-    func draw(_ image: SVG, in rect: CGRect? = nil)  {
-        let defaultRect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+    func draw(_ svg: SVG, in rect: CGRect? = nil)  {
+        let defaultRect = CGRect(x: 0, y: 0, width: svg.size.width, height: svg.size.height)
         let renderer = CGRenderer(context: self)
         saveGState()
 
         if let rect = rect, rect != defaultRect {
             translateBy(x: rect.origin.x, y: rect.origin.y)
             scaleBy(
-                x: rect.width / image.size.width,
-                y: rect.height / image.size.height
+                x: rect.width / svg.size.width,
+                y: rect.height / svg.size.height
             )
         }
-        renderer.perform(image.commands)
+        renderer.perform(svg.commands)
 
         restoreGState()
+    }
+
+    func draw(_ svg: SVG, in rect: CGRect, byTiling: Bool) {
+        guard byTiling else {
+            draw(svg, in: rect)
+            return
+        }
+
+        let cols = Int(ceil(rect.size.width / svg.size.width))
+        let rows = Int(ceil(rect.size.height / svg.size.height))
+
+        for r in 0..<rows {
+            for c in 0..<cols {
+                let tile = CGRect(
+                    x: rect.minX + CGFloat(r) * svg.size.width,
+                    y: rect.minY + CGFloat(c) * svg.size.height,
+                    width: svg.size.width,
+                    height: svg.size.height
+                )
+                draw(svg, in: tile)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds `.resizable()` to `SVGView` enabling it to function just like `SwiftUI.Image` 

```xml
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100" height="100">
    <circle cx="50" cy="50" r="50" fill="orange" />
</svg>
```


```swift
#Preview {
    SVGView(svg: .circle)

    SVGView(svg: .circle)
       .resizable(resizingMode: .stretch)

    SVGView(svg: .circle)
       .resizable(resizingMode: .tile)
}
```

<img width="374" height="692" alt="preview" src="https://github.com/user-attachments/assets/17919188-96d4-4dcb-8faa-0dbfabce0aee" />

