### PR TITLE
UIGraphicsImageRendererContext helpers + MacCatalyst fix.

### DIFF
--- a/SwiftDraw/Sources/CanvasNSView.swift
+++ b/SwiftDraw/Sources/CanvasNSView.swift
@@ -29,7 +29,7 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import SwiftUI
 

--- a/SwiftDraw/Sources/SVG+UIGraphicsImageRendererContext.swift
+++ b/SwiftDraw/Sources/SVG+UIGraphicsImageRendererContext.swift
@@ -1,0 +1,31 @@
+//
+//  SVG+UIGraphicsImageRendererContext.swift
+//  SwiftDraw
+//
+//  Created by Daniel on 10/14/25.
+//
+
+#if canImport(UIKit)
+public import CoreGraphics
+public import UIKit
+
+public extension UIGraphicsImageRendererContext {
+  
+  func draw(_ svg: SVG, in rect: CGRect? = nil)  {
+    self.cgContext.draw(svg, in: rect)
+  }
+  
+  func draw(_ svg: SVG, in rect: CGRect, byTiling: Bool) {
+    self.cgContext.draw(svg, in: rect, byTiling: byTiling)
+  }
+  
+  func draw(
+    _ svg: SVG,
+    in rect: CGRect,
+    capInsets: (top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat),
+    byTiling: Bool
+  ) {
+    self.cgContext.draw(svg, in: rect, capInsets: capInsets, byTiling: byTiling)
+  }
+}
+#endif


### PR DESCRIPTION
- The latest tag doesn't build on MacCatalyst, so adding a pre-processor directive to fix it.
- I was getting a crash on `UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0)` and the output suggested using `UIGraphicsImageRenderer` which offers a `UIGraphicsImageRendererContext` to draw in. This motivated the new `UIKit`-only extension.

Here is the output from Xcode.
```
UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={-6, 22.5}, scale=2.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.
```