### PR TITLE
Add regression test for SVG length unit conversion

### DIFF
--- a/DOM/Tests/Parser.SVGTests.swift
+++ b/DOM/Tests/Parser.SVGTests.swift
@@ -57,6 +57,18 @@ struct ParserSVGTests {
     }
 
     @Test
+    func svgWithUnits() throws {
+        let node = XML.Element(name: "svg", attributes: ["width": "10cm", "height": "2in"])
+        let parser = DOMXMLParser()
+
+        let parsed = try parser.parseSVG(node)
+        // 10cm = 10 * 37.795 = 377.95 → truncated to 377
+        #expect(parsed.width == 377)
+        // 2in = 2 * 96 = 192
+        #expect(parsed.height == 192)
+    }
+
+    @Test
     func parseSVGInvalidNode() {
         let node = XML.Element(name: "svg2", attributes: ["width": "100", "height": "200"])
         #expect(throws: (any Error).self) {


### PR DESCRIPTION
## Summary
- Adds a test verifying SVG root width/height attributes with units (cm, in) are correctly converted to pixels
- The unit conversion was already implemented (`10cm` → 377px, `2in` → 192px) but lacked a specific test for SVG root element parsing

## Test plan
- [x] Added `svgWithUnits()` test verifying `width="10cm"` → 377 and `height="2in"` → 192
- [x] All 194 tests pass

Relates to #42