### PR TITLE
Auto-generate SF Symbol weight variants from stroke-width scaling

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -92,11 +92,17 @@ Available keys for --format swift:
 Available keys for --format sfsymbol:
  --insets             alignment of regular variant: top,left,bottom,right | auto
  --size               size category to generate: small, medium large. (default is small)
- --ultralight         svg file of ultralight variant
- --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
- --black              svg file of black variant
- --black-insets       alignment of black variant: top,left,bottom,right | auto
- --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
+ --ultralight               svg file of ultralight variant
+ --ultralight-insets        alignment of ultralight variant: top,left,bottom,right | auto
+ --ultralight-stroke-width  auto-generate ultralight variant by scaling regular stroke-width: 0.5 | 50%
+ --black                    svg file of black variant
+ --black-insets             alignment of black variant: top,left,bottom,right | auto
+ --black-stroke-width       auto-generate black variant by scaling regular stroke-width: 2.0 | 200%
+ --legacy                   use the original, less precise alignment logic from earlier swiftdraw versions.
+
+Notes:
+ An explicit --ultralight or --black file always wins over the matching stroke-width flag.
+ Stroke-width scaling has no effect on shapes that lack a stroke (a warning is printed).
 
 
 """)

--- a/README.md
+++ b/README.md
@@ -114,11 +114,13 @@ Available keys for --format swift:
 Available keys for --format sfsymbol:
  --insets             alignment of regular variant: top,left,bottom,right | auto
  --size               size category to generate: small, medium large. (default is small)
- --ultralight         svg file of ultralight variant
- --ultralight-insets  alignment of ultralight variant: top,left,bottom,right | auto
- --black              svg file of black variant
- --black-insets       alignment of black variant: top,left,bottom,right | auto
- --legacy             use the original, less precise alignment logic from earlier swiftdraw versions.
+ --ultralight               svg file of ultralight variant
+ --ultralight-insets        alignment of ultralight variant: top,left,bottom,right | auto
+ --ultralight-stroke-width  auto-generate ultralight variant by scaling regular stroke-width: 0.5 | 50%
+ --black                    svg file of black variant
+ --black-insets             alignment of black variant: top,left,bottom,right | auto
+ --black-stroke-width       auto-generate black variant by scaling regular stroke-width: 2.0 | 200%
+ --legacy                   use the original, less precise alignment logic from earlier swiftdraw versions.
 ```
 
 ```bash
@@ -178,6 +180,21 @@ Alignment: --insets 40,30,40,30
 ```
 
 Variants can also be aligned using `--ultralightInsets` and `--blackInsets`.
+
+#### Auto-generated weight variants
+
+When matching ultralight or black SVGs are not available, SwiftDraw can synthesize them from the regular SVG by scaling every `stroke-width` value before strokes are expanded. Both decimal and percent forms are accepted:
+
+```bash
+$ swiftdraw key.svg --format sfsymbol \
+    --ultralight-stroke-width 50% \
+    --black-stroke-width 2.0
+```
+
+Notes:
+ - An explicit `--ultralight` or `--black` SVG always wins over the matching `--*-stroke-width` flag. A warning is printed if both are supplied.
+ - The scaler walks element attributes, inline styles, and `<style>` rules. If the regular SVG has no `stroke-width` values to scale, a warning is printed and the regular paths are reused unchanged.
+ - Only `stroke-width` is scaled today. Future work could add scaling for related attributes (for example, dash arrays).
 
 ### Swift Code Generation
 

--- a/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine+Process.swift
@@ -58,7 +58,9 @@ public extension CommandLine {
                 insetsUltralight: config.insetsUltralight ?? config.insets,
                 insetsBlack: config.insetsBlack ?? config.insets,
                 precision: config.precision ?? 3,
-                isLegacyInsets: config.isLegacyInsetsEnabled
+                isLegacyInsets: config.isLegacyInsetsEnabled,
+                ultralightStrokeScale: config.ultralightStrokeScale,
+                blackStrokeScale: config.blackStrokeScale
             )
             let svg = try renderer.render(
                 regular: config.input,

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Arguments.swift
@@ -43,8 +43,10 @@ extension CommandLine {
         case api
         case ultralight
         case ultralightInsets
+        case ultralightStrokeWidth
         case black
         case blackInsets
+        case blackStrokeWidth
         case hideUnsupportedFilters
         case legacy
 
@@ -65,8 +67,12 @@ extension CommandLine {
             switch text {
             case "ultralight-insets":
                 return .ultralightInsets
+            case "ultralight-stroke-width":
+                return .ultralightStrokeWidth
             case "black-insets":
                 return .blackInsets
+            case "black-stroke-width":
+                return .blackStrokeWidth
             case "hide-unsupported-filters":
                 return .hideUnsupportedFilters
             default:

--- a/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
+++ b/SwiftDraw/Sources/CommandLine/CommandLine.Configuration.swift
@@ -50,6 +50,8 @@ extension CommandLine {
         public var precision: Int?
         public var symbolSize: SFSymbolRenderer.SizeCategory?
         public var isLegacyInsetsEnabled: Bool
+        public var ultralightStrokeScale: SFSymbolRenderer.StrokeWidthScale?
+        public var blackStrokeScale: SFSymbolRenderer.StrokeWidthScale?
     }
 
     public enum Format: String {
@@ -116,8 +118,10 @@ extension CommandLine {
         let api = try parseAPI(from: modifiers[.api])
         let ultralight = try parseFileURL(file: modifiers[.ultralight], within: baseDirectory)
         let ultralightInsets = try parseInsets(from: modifiers[.ultralightInsets])
+        let ultralightStroke = try parseStrokeScale(from: modifiers[.ultralightStrokeWidth])
         let black = try parseFileURL(file: modifiers[.black], within: baseDirectory)
         let blackInsets = try parseInsets(from: modifiers[.blackInsets])
+        let blackStroke = try parseStrokeScale(from: modifiers[.blackStrokeWidth])
         let output = try parseFileURL(file: modifiers[.output], within: baseDirectory)
         let symbolSize = try parseSymbolSize(from: modifiers[.size], format: format)
 
@@ -138,8 +142,21 @@ extension CommandLine {
             options: options,
             precision: precision,
             symbolSize: symbolSize,
-            isLegacyInsetsEnabled: modifiers.keys.contains(.legacy)
+            isLegacyInsetsEnabled: modifiers.keys.contains(.legacy),
+            ultralightStrokeScale: ultralightStroke,
+            blackStrokeScale: blackStroke
         )
+    }
+
+    static func parseStrokeScale(from value: String??) throws -> SFSymbolRenderer.StrokeWidthScale? {
+        guard let value = value,
+              let value = value else {
+            return nil
+        }
+        guard let scale = SFSymbolRenderer.StrokeWidthScale(rawValue: value) else {
+            throw Error.invalid
+        }
+        return scale
     }
 
     static func parseFileURL(file: String, within directory: URL) throws -> URL {

--- a/SwiftDraw/Sources/Renderer/Renderer.SFSymbol+StrokeScale.swift
+++ b/SwiftDraw/Sources/Renderer/Renderer.SFSymbol+StrokeScale.swift
@@ -1,0 +1,129 @@
+//
+//  Renderer.SFSymbol+StrokeScale.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 22/4/26.
+//  Copyright 2026 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import SwiftDrawDOM
+import Foundation
+
+public extension SFSymbolRenderer {
+
+    /// Multiplier applied to every stroke-width in a source SVG when generating
+    /// an autoscaled weight variant. Accepts decimal (`0.5`) and percent (`50%`) syntax
+    struct StrokeWidthScale: Equatable, Sendable {
+        public let multiplier: Double
+
+        public init(multiplier: Double) {
+            self.multiplier = multiplier
+        }
+
+        public init?(rawValue: String) {
+            let trimmed = rawValue.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            if trimmed.hasSuffix("%") {
+                let body = trimmed.dropLast()
+                guard let value = Double(body), value > 0 else { return nil }
+                self.multiplier = value / 100.0
+            } else {
+                guard let value = Double(trimmed), value > 0 else { return nil }
+                self.multiplier = value
+            }
+        }
+    }
+}
+
+enum StrokeWidthScaler {
+
+    /// Walks the SVG DOM and multiplies every stroke-width it finds (element attributes,
+    /// inline styles, and stylesheet rules) by `scale`. Returns the number of values mutated
+    @discardableResult
+    static func scale(_ svg: DOM.SVG, by scale: SFSymbolRenderer.StrokeWidthScale) -> Int {
+        var count = 0
+        scaleAttributes(of: svg, by: scale, count: &count)
+        scaleChildren(of: svg, by: scale, count: &count)
+        scaleDefs(&svg.defs, by: scale, count: &count)
+        scaleStyles(&svg.styles, by: scale, count: &count)
+        return count
+    }
+
+    private static func scaleChildren(of container: any ContainerElement, by scale: SFSymbolRenderer.StrokeWidthScale, count: inout Int) {
+        for child in container.childElements {
+            scaleAttributes(of: child, by: scale, count: &count)
+            if let nested = child as? any ContainerElement {
+                scaleChildren(of: nested, by: scale, count: &count)
+            }
+        }
+    }
+
+    private static func scaleAttributes(of element: DOM.GraphicsElement, by scale: SFSymbolRenderer.StrokeWidthScale, count: inout Int) {
+        if let value = element.attributes.strokeWidth {
+            element.attributes.strokeWidth = multiply(value, by: scale)
+            count += 1
+        }
+        if let value = element.style.strokeWidth {
+            element.style.strokeWidth = multiply(value, by: scale)
+            count += 1
+        }
+    }
+
+    private static func scaleDefs(_ defs: inout DOM.SVG.Defs, by scale: SFSymbolRenderer.StrokeWidthScale, count: inout Int) {
+        for clipPath in defs.clipPaths {
+            scaleChildren(of: clipPath, by: scale, count: &count)
+        }
+        for mask in defs.masks {
+            scaleAttributes(of: mask, by: scale, count: &count)
+            scaleChildren(of: mask, by: scale, count: &count)
+        }
+        for pattern in defs.patterns {
+            scaleChildren(of: pattern, by: scale, count: &count)
+        }
+        for element in defs.elements.values {
+            scaleAttributes(of: element, by: scale, count: &count)
+            if let container = element as? any ContainerElement {
+                scaleChildren(of: container, by: scale, count: &count)
+            }
+        }
+    }
+
+    private static func scaleStyles(_ styles: inout [DOM.StyleSheet], by scale: SFSymbolRenderer.StrokeWidthScale, count: inout Int) {
+        for sheetIndex in styles.indices {
+            for selector in styles[sheetIndex].attributes.keys {
+                if let value = styles[sheetIndex].attributes[selector]?.strokeWidth {
+                    styles[sheetIndex].attributes[selector]?.strokeWidth = multiply(value, by: scale)
+                    count += 1
+                }
+            }
+        }
+    }
+
+    private static func multiply(_ value: DOM.Float, by scale: SFSymbolRenderer.StrokeWidthScale) -> DOM.Float {
+        DOM.Float(Double(value) * scale.multiplier)
+    }
+}
+

--- a/SwiftDraw/Sources/Renderer/Renderer.SFSymbol.swift
+++ b/SwiftDraw/Sources/Renderer/Renderer.SFSymbol.swift
@@ -41,6 +41,8 @@ public struct SFSymbolRenderer {
     private let insetsBlack: CommandLine.Insets
     private let formatter: CoordinateFormatter
     private let isLegacyInsets: Bool
+    private let ultralightStrokeScale: StrokeWidthScale?
+    private let blackStrokeScale: StrokeWidthScale?
 
     public enum SizeCategory {
         case small
@@ -55,7 +57,9 @@ public struct SFSymbolRenderer {
         insetsUltralight: CommandLine.Insets,
         insetsBlack: CommandLine.Insets,
         precision: Int,
-        isLegacyInsets: Bool
+        isLegacyInsets: Bool,
+        ultralightStrokeScale: StrokeWidthScale? = nil,
+        blackStrokeScale: StrokeWidthScale? = nil
     ) {
         self.size = size
         self.options = options
@@ -67,13 +71,41 @@ public struct SFSymbolRenderer {
             precision: .capped(max: precision)
         )
         self.isLegacyInsets = isLegacyInsets
+        self.ultralightStrokeScale = ultralightStrokeScale
+        self.blackStrokeScale = blackStrokeScale
     }
 
     public func render(regular: URL, ultralight: URL?, black: URL?) throws -> String {
-        let regular = try DOM.SVG.parse(fileURL: regular)
-        let ultralight = try ultralight.map { try DOM.SVG.parse(fileURL: $0) }
-        let black = try black.map { try DOM.SVG.parse(fileURL: $0) }
-        return try render(default: regular, ultralight: ultralight, black: black)
+        let regularDOM = try DOM.SVG.parse(fileURL: regular)
+        let ultralightDOM = try makeVariant(
+            regular: regular,
+            explicit: ultralight,
+            scale: ultralightStrokeScale,
+            variant: .ultralight
+        )
+        let blackDOM = try makeVariant(
+            regular: regular,
+            explicit: black,
+            scale: blackStrokeScale,
+            variant: .black
+        )
+        return try render(default: regularDOM, ultralight: ultralightDOM, black: blackDOM)
+    }
+
+    private func makeVariant(regular: URL, explicit: URL?, scale: StrokeWidthScale?, variant: Variant) throws -> DOM.SVG? {
+        if let explicit {
+            if scale != nil {
+                print("Warning:", "explicit --\(variant.rawValue) overrides --\(variant.rawValue)-stroke-width.", to: &.standardError)
+            }
+            return try DOM.SVG.parse(fileURL: explicit)
+        }
+        guard let scale else { return nil }
+        let dom = try DOM.SVG.parse(fileURL: regular)
+        let count = StrokeWidthScaler.scale(dom, by: scale)
+        if count == 0 {
+            print("Warning:", "--\(variant.rawValue)-stroke-width has no effect: source SVG has no stroke-width values.", to: &.standardError)
+        }
+        return dom
     }
 
     func render(default image: DOM.SVG, ultralight: DOM.SVG?, black: DOM.SVG?) throws -> String {

--- a/SwiftDraw/Tests/CommandLine/CommandLine.ConfigurationTests.swift
+++ b/SwiftDraw/Tests/CommandLine/CommandLine.ConfigurationTests.swift
@@ -252,6 +252,39 @@ final class CommandLineConfigurationTests: XCTestCase {
         XCTAssertFalse(CommandLine.Insets(bottom: 1).isEmpty)
         XCTAssertFalse(CommandLine.Insets(right: 1).isEmpty)
     }
+
+    func testParseConfigurationUltralightStrokeWidth() throws {
+        let config = try parseConfiguration(
+            "swiftdraw", "file.svg", "--format", "sfsymbol",
+            "--ultralight-stroke-width", "50%"
+        )
+        XCTAssertEqual(config.ultralightStrokeScale?.multiplier, 0.5)
+        XCTAssertNil(config.blackStrokeScale)
+    }
+
+    func testParseConfigurationBlackStrokeWidth() throws {
+        let config = try parseConfiguration(
+            "swiftdraw", "file.svg", "--format", "sfsymbol",
+            "--black-stroke-width", "2"
+        )
+        XCTAssertEqual(config.blackStrokeScale?.multiplier, 2.0)
+        XCTAssertNil(config.ultralightStrokeScale)
+    }
+
+    func testParseConfigurationStrokeWidthInvalid() {
+        XCTAssertThrowsError(
+            try parseConfiguration(
+                "swiftdraw", "file.svg", "--format", "sfsymbol",
+                "--ultralight-stroke-width", "abc"
+            )
+        )
+        XCTAssertThrowsError(
+            try parseConfiguration(
+                "swiftdraw", "file.svg", "--format", "sfsymbol",
+                "--black-stroke-width", "0"
+            )
+        )
+    }
 }
 
 private func parseConfiguration(_ args: String...) throws -> CommandLine.Configuration {

--- a/SwiftDraw/Tests/Renderer/Renderer.SFSymbolStrokeScaleTests.swift
+++ b/SwiftDraw/Tests/Renderer/Renderer.SFSymbolStrokeScaleTests.swift
@@ -1,0 +1,241 @@
+//
+//  Renderer.SFSymbolStrokeScaleTests.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 22/4/26.
+//  Copyright 2026 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import SwiftDrawDOM
+import XCTest
+@testable import SwiftDraw
+
+final class RendererSFSymbolStrokeScaleTests: XCTestCase {
+
+    // MARK: - StrokeWidthScale parser
+
+    func testParsesDecimal() throws {
+        let scale = try XCTUnwrap(SFSymbolRenderer.StrokeWidthScale(rawValue: "0.5"))
+        XCTAssertEqual(scale.multiplier, 0.5)
+    }
+
+    func testParsesInteger() throws {
+        let scale = try XCTUnwrap(SFSymbolRenderer.StrokeWidthScale(rawValue: "2"))
+        XCTAssertEqual(scale.multiplier, 2.0)
+    }
+
+    func testParsesPercent() throws {
+        let scale = try XCTUnwrap(SFSymbolRenderer.StrokeWidthScale(rawValue: "50%"))
+        XCTAssertEqual(scale.multiplier, 0.5)
+    }
+
+    func testParsesPercentAboveOneHundred() throws {
+        let scale = try XCTUnwrap(SFSymbolRenderer.StrokeWidthScale(rawValue: "200%"))
+        XCTAssertEqual(scale.multiplier, 2.0)
+    }
+
+    func testParsesWithSurroundingWhitespace() throws {
+        let scale = try XCTUnwrap(SFSymbolRenderer.StrokeWidthScale(rawValue: "  75%  "))
+        XCTAssertEqual(scale.multiplier, 0.75)
+    }
+
+    func testRejectsZero() {
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "0"))
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "0%"))
+    }
+
+    func testRejectsNegative() {
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "-1"))
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "-50%"))
+    }
+
+    func testRejectsEmpty() {
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: ""))
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "   "))
+    }
+
+    func testRejectsMalformed() {
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "abc"))
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "1.5x"))
+        XCTAssertNil(SFSymbolRenderer.StrokeWidthScale(rawValue: "%50"))
+    }
+
+    // MARK: - Walker on element attributes
+
+    func testScalesElementStrokeWidthAttribute() throws {
+        let url = try Bundle.test.url(forResource: "stroke-attribute.svg")
+        let svg = try DOM.SVG.parse(fileURL: url)
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 0.5))
+
+        XCTAssertEqual(count, 1)
+        let line = try XCTUnwrap(svg.childElements.first as? DOM.Line)
+        XCTAssertEqual(line.attributes.strokeWidth, 2)
+    }
+
+    // MARK: - Walker on inline style
+
+    func testScalesInlineStyleStrokeWidth() throws {
+        let url = try Bundle.test.url(forResource: "stroke-inline-style.svg")
+        let svg = try DOM.SVG.parse(fileURL: url)
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 2.0))
+
+        XCTAssertEqual(count, 1)
+        let line = try XCTUnwrap(svg.childElements.first as? DOM.Line)
+        XCTAssertEqual(line.style.strokeWidth, 12)
+    }
+
+    // MARK: - Walker on stylesheet
+
+    func testScalesStylesheetStrokeWidth() throws {
+        let url = try Bundle.test.url(forResource: "stroke-stylesheet.svg")
+        let svg = try DOM.SVG.parse(fileURL: url)
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 0.25))
+
+        XCTAssertEqual(count, 1)
+        let sheet = try XCTUnwrap(svg.styles.first)
+        let attrs = try XCTUnwrap(sheet.attributes[.class("bar")])
+        XCTAssertEqual(attrs.strokeWidth, 2)
+    }
+
+    // MARK: - Walker across all sources
+
+    func testScalesAcrossAllSources() throws {
+        let url = try Bundle.test.url(forResource: "stroke-mixed.svg")
+        let svg = try DOM.SVG.parse(fileURL: url)
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 2.0))
+
+        // 4 stroke-width values: group attribute (3 -> 6),
+        // line attribute (4 -> 8), inline style (5 -> 10), stylesheet (2 -> 4)
+        XCTAssertEqual(count, 4)
+    }
+
+    // MARK: - Walker reports zero when nothing to scale
+
+    func testReportsZeroWhenNoStrokes() throws {
+        let url = try Bundle.test.url(forResource: "stroke-none.svg")
+        let svg = try DOM.SVG.parse(fileURL: url)
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 0.5))
+
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - Walker recurses through groups
+
+    func testScalesNestedGroups() throws {
+        let svg = try DOM.SVG.parse(xml: #"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="black" stroke-width="10">
+                <g stroke-width="20">
+                    <line x1="0" y1="0" x2="100" y2="100" stroke-width="30"/>
+                </g>
+            </g>
+        </svg>
+        """#)
+
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 0.5))
+        XCTAssertEqual(count, 3)
+    }
+
+    // MARK: - Walker visits clipPath defs
+
+    func testScalesInsideClipPath() throws {
+        let svg = try DOM.SVG.parse(xml: #"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <clipPath id="cp">
+                    <rect x="0" y="0" width="50" height="50" stroke-width="6"/>
+                </clipPath>
+            </defs>
+            <rect x="0" y="0" width="100" height="100" stroke="black" stroke-width="4" clip-path="url(#cp)"/>
+        </svg>
+        """#)
+
+        let count = StrokeWidthScaler.scale(svg, by: .init(multiplier: 0.5))
+        XCTAssertEqual(count, 2)
+    }
+
+    // MARK: - Integration through SFSymbolRenderer
+
+    func testRendersUltralightVariantFromScale() throws {
+        let url = try Bundle.test.url(forResource: "chart.svg")
+        let renderer = SFSymbolRenderer.makeStrokeScaling(
+            ultralight: .init(multiplier: 0.5),
+            black: .init(multiplier: 2.0)
+        )
+        let template = try SFSymbolTemplate.parse(
+            try renderer.render(regular: url, ultralight: nil, black: nil)
+        )
+
+        XCTAssertFalse(template.ultralight.contents.paths.isEmpty)
+        XCTAssertFalse(template.regular.contents.paths.isEmpty)
+        XCTAssertFalse(template.black.contents.paths.isEmpty)
+    }
+
+    func testStrokeScaledVariantsDifferFromRegular() throws {
+        // Heavier strokes expand outlines into wider paths, so the ultralight
+        // and black variants should not be byte-identical to regular
+        let url = try Bundle.test.url(forResource: "chart.svg")
+        let renderer = SFSymbolRenderer.makeStrokeScaling(
+            ultralight: .init(multiplier: 0.25),
+            black: .init(multiplier: 4.0)
+        )
+        let template = try SFSymbolTemplate.parse(
+            try renderer.render(regular: url, ultralight: nil, black: nil)
+        )
+
+        let ultralightPaths = template.ultralight.contents.paths
+        let regularPaths = template.regular.contents.paths
+        let blackPaths = template.black.contents.paths
+
+        XCTAssertEqual(ultralightPaths.count, regularPaths.count)
+        XCTAssertEqual(blackPaths.count, regularPaths.count)
+
+        let ultralightSegments = ultralightPaths.flatMap(\.segments)
+        let regularSegments = regularPaths.flatMap(\.segments)
+        let blackSegments = blackPaths.flatMap(\.segments)
+        XCTAssertNotEqual(ultralightSegments, regularSegments)
+        XCTAssertNotEqual(blackSegments, regularSegments)
+    }
+}
+
+private extension SFSymbolRenderer {
+
+    static func makeStrokeScaling(ultralight: StrokeWidthScale?, black: StrokeWidthScale?) -> SFSymbolRenderer {
+        SFSymbolRenderer(
+            size: .small,
+            options: [],
+            insets: .init(),
+            insetsUltralight: .init(),
+            insetsBlack: .init(),
+            precision: 3,
+            isLegacyInsets: false,
+            ultralightStrokeScale: ultralight,
+            blackStrokeScale: black
+        )
+    }
+}

--- a/SwiftDraw/Tests/Test.bundle/stroke-attribute.svg
+++ b/SwiftDraw/Tests/Test.bundle/stroke-attribute.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <line x1="10" y1="50" x2="90" y2="50" stroke="black" stroke-width="4"/>
+</svg>

--- a/SwiftDraw/Tests/Test.bundle/stroke-inline-style.svg
+++ b/SwiftDraw/Tests/Test.bundle/stroke-inline-style.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <line x1="10" y1="50" x2="90" y2="50" style="stroke:black;stroke-width:6"/>
+</svg>

--- a/SwiftDraw/Tests/Test.bundle/stroke-mixed.svg
+++ b/SwiftDraw/Tests/Test.bundle/stroke-mixed.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .css { stroke: black; stroke-width: 2; }
+    </style>
+    <g stroke-width="3" stroke="black">
+        <line x1="0" y1="20" x2="100" y2="20" stroke-width="4"/>
+        <line x1="0" y1="40" x2="100" y2="40" style="stroke-width:5"/>
+        <line class="css" x1="0" y1="60" x2="100" y2="60"/>
+    </g>
+</svg>

--- a/SwiftDraw/Tests/Test.bundle/stroke-none.svg
+++ b/SwiftDraw/Tests/Test.bundle/stroke-none.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="80" height="80" fill="black"/>
+</svg>

--- a/SwiftDraw/Tests/Test.bundle/stroke-stylesheet.svg
+++ b/SwiftDraw/Tests/Test.bundle/stroke-stylesheet.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .bar { stroke: black; stroke-width: 8; }
+    </style>
+    <line class="bar" x1="10" y1="50" x2="90" y2="50"/>
+</svg>


### PR DESCRIPTION
Fixes #38

## Summary

Adds two new flags to the `sfsymbol` format that synthesize the ultralight and black weight variants directly from the regular SVG by scaling every `stroke-width` value before strokes get expanded into outlines:

- `--ultralight-stroke-width <scale>` — typically `0.5` or `50%`
- `--black-stroke-width <scale>` — typically `2.0` or `200%`

Both decimal (`0.5`) and percent (`50%`) syntax are accepted. The existing `--ultralight <file>` and `--black <file>` flags still work and take precedence; a warning is printed when both are supplied.

## Implementation

- `SFSymbolRenderer.StrokeWidthScale`: small value type with a permissive parser (rejects `0`, negative, malformed, empty)
- `StrokeWidthScaler`: walks a `DOM.SVG` and multiplies stroke-width on
    1. element `attributes`
    2. element inline `style`
    3. `<style>` rules in every `StyleSheet`
  Recurses through groups, clipPath/mask/pattern containers in `defs`, and the `defs.elements` dictionary. Returns the count of values mutated so the caller can warn when no strokes were found
- `SFSymbolRenderer.render(regular:ultralight:black:)`: when a scale is supplied without an explicit variant URL, re-parses the regular file (DOM nodes are reference types so a fresh parse is the cleanest deep clone), runs the scaler, and feeds the mutated DOM into the existing variant pipeline. No path/layer/codegen changes were needed
- CLI: new `Modifier` cases, `parseStrokeScale` helper, threading through `Configuration` and `processImage`, updated `--help` text
- README: documents the flags, syntax, the explicit-wins rule, the no-strokes warning, and notes that only `stroke-width` is scaled today (future work could cover dash arrays and similar)

Output emits these warnings to `stderr`:

- `--ultralight-stroke-width has no effect: source SVG has no stroke-width values.`
- `explicit --ultralight overrides --ultralight-stroke-width.`

## Tests

`RendererSFSymbolStrokeScaleTests` (18 tests) covers the parser, the walker against each of the three stroke-width sources individually plus a mixed fixture, nested group recursion, clipPath children, the no-strokes case, and end-to-end runs through `SFSymbolRenderer` confirming the variant paths actually differ from regular when scaled. `CommandLineConfigurationTests` adds three tests for the new flags (valid decimal, valid percent, invalid value rejection).

Five new fixtures cover the stroke sources independently:

| Fixture | Source |
| --- | --- |
| `stroke-attribute.svg` | element attribute |
| `stroke-inline-style.svg` | inline `style=` |
| `stroke-stylesheet.svg` | `<style>` selector |
| `stroke-mixed.svg` | all three plus a group ancestor |
| `stroke-none.svg` | no strokes (warning path) |

Full suite: `swift test` — 217 tests pass, 0 failures.

## Test plan
- [ ] `swift test` passes locally
- [ ] `swiftdraw key.svg --format sfsymbol --ultralight-stroke-width 50% --black-stroke-width 2.0` produces a valid template
- [ ] Warning prints when source has no strokes
- [ ] Warning prints when explicit `--ultralight` and `--ultralight-stroke-width` are both supplied