### PR TITLE
Fix gradient coordinate percentage parsing

### DIFF
--- a/DOM/Sources/Parser.XML.Attributes.swift
+++ b/DOM/Sources/Parser.XML.Attributes.swift
@@ -112,7 +112,12 @@ extension XMLParser {
       var scanner = XMLParser.Scanner(text: value)
       return try scanner.scanCoordinate()
     }
-    
+
+    func parseCoordinateOrPercentage(_ value: String) throws -> DOM.Coordinate {
+      var scanner = XMLParser.Scanner(text: value)
+      return try scanner.scanCoordinateOrPercentage()
+    }
+
     func parseLength(_ value: String) throws -> DOM.Length {
       var scanner = XMLParser.Scanner(text: value)
       return try scanner.scanLength()

--- a/DOM/Sources/Parser.XML.LinearGradient.swift
+++ b/DOM/Sources/Parser.XML.LinearGradient.swift
@@ -51,10 +51,10 @@ extension XMLParser {
 
         let nodeAtt: any AttributeParser = try parseAttributes(e)
         let node = DOM.LinearGradient(id: try nodeAtt.parseString("id"))
-        node.x1 = try nodeAtt.parseCoordinate("x1")
-        node.y1 = try nodeAtt.parseCoordinate("y1")
-        node.x2 = try nodeAtt.parseCoordinate("x2")
-        node.y2 = try nodeAtt.parseCoordinate("y2")
+        node.x1 = try nodeAtt.parseCoordinateOrPercentage("x1")
+        node.y1 = try nodeAtt.parseCoordinateOrPercentage("y1")
+        node.x2 = try nodeAtt.parseCoordinateOrPercentage("x2")
+        node.y2 = try nodeAtt.parseCoordinateOrPercentage("y2")
 
         for n in e.children where n.name == "stop" {
             let att: any AttributeParser = try parseAttributes(n)

--- a/DOM/Sources/Parser.XML.RadialGradient.swift
+++ b/DOM/Sources/Parser.XML.RadialGradient.swift
@@ -51,12 +51,12 @@ extension XMLParser {
 
         let nodeAtt: any AttributeParser = try parseAttributes(e)
         let node = DOM.RadialGradient(id: try nodeAtt.parseString("id"))
-        node.r = try? nodeAtt.parseCoordinate("r")
-        node.cx = try? nodeAtt.parseCoordinate("cx")
-        node.cy = try? nodeAtt.parseCoordinate("cy")
-        node.fr = try? nodeAtt.parseCoordinate("fr")
-        node.fx = try? nodeAtt.parseCoordinate("fx")
-        node.fy = try? nodeAtt.parseCoordinate("fy")
+        node.r = try? nodeAtt.parseCoordinateOrPercentage("r")
+        node.cx = try? nodeAtt.parseCoordinateOrPercentage("cx")
+        node.cy = try? nodeAtt.parseCoordinateOrPercentage("cy")
+        node.fr = try? nodeAtt.parseCoordinateOrPercentage("fr")
+        node.fx = try? nodeAtt.parseCoordinateOrPercentage("fx")
+        node.fy = try? nodeAtt.parseCoordinateOrPercentage("fy")
 
         for n in e.children where n.name == "stop" {
             let att: any AttributeParser = try parseAttributes(n)

--- a/DOM/Sources/Parser.XML.Scanner.swift
+++ b/DOM/Sources/Parser.XML.Scanner.swift
@@ -311,6 +311,17 @@ package extension XMLParser {
             let unit = scanUnit() ?? .pixel
             return DOM.Coordinate(double.apply(unit: unit))
         }
+
+        package mutating func scanCoordinateOrPercentage() throws -> DOM.Coordinate {
+            let double = try scanDouble()
+            scanner.currentIndex = currentIndex
+            if scanner.scanString("%") != nil {
+                currentIndex = scanner.currentIndex
+                return DOM.Coordinate(double / 100.0)
+            }
+            let unit = scanUnit() ?? .pixel
+            return DOM.Coordinate(double.apply(unit: unit))
+        }
         
         package mutating func scanPercentageFloat() throws -> Float {
             scanner.currentIndex = currentIndex

--- a/DOM/Sources/Parser.XML.swift
+++ b/DOM/Sources/Parser.XML.swift
@@ -65,6 +65,7 @@ package protocol AttributeValueParser {
     func parseFloats(_ value: String) throws -> [DOM.Float]
     func parsePercentage(_ value: String) throws -> DOM.Float
     func parseCoordinate(_ value: String) throws -> DOM.Coordinate
+    func parseCoordinateOrPercentage(_ value: String) throws -> DOM.Coordinate
     func parseLength(_ value: String) throws -> DOM.Length
     func parseBool(_ value: String) throws -> DOM.Bool
     func parseFill(_ value: String) throws -> DOM.Fill
@@ -106,6 +107,10 @@ package extension AttributeParser {
 
     func parseCoordinate(_ key: String) throws -> DOM.Coordinate {
         return try parse(key) { return try parser.parseCoordinate($0) }
+    }
+
+    func parseCoordinateOrPercentage(_ key: String) throws -> DOM.Coordinate {
+        return try parse(key) { return try parser.parseCoordinateOrPercentage($0) }
     }
 
     func parseLength(_ key: String) throws -> DOM.Length {
@@ -185,6 +190,10 @@ package extension AttributeParser {
 
     func parseCoordinate(_ key: String) throws -> DOM.Coordinate? {
         return try parse(key) { return try parser.parseCoordinate($0) }
+    }
+
+    func parseCoordinateOrPercentage(_ key: String) throws -> DOM.Coordinate? {
+        return try parse(key) { return try parser.parseCoordinateOrPercentage($0) }
     }
 
     func parseLength(_ key: String) throws -> DOM.Length? {

--- a/DOM/Tests/Parser.XML.LinearGradientTests.swift
+++ b/DOM/Tests/Parser.XML.LinearGradientTests.swift
@@ -50,6 +50,38 @@ struct ParserXMLLinearGradientTests {
     }
 
     @Test
+    func parseCoordinatesWithPercentage() throws {
+        let element = XML.Element(name: "linearGradient", attributes: [
+            "id": "a",
+            "x1": "3.309%",
+            "y1": "28.41%",
+            "x2": "103.216%",
+            "y2": "64.511%"
+        ])
+        let gradient = try XMLParser().parseLinearGradient(element)
+        #expect(abs((gradient.x1 ?? 0) - 0.03309) < 0.0001)
+        #expect(abs((gradient.y1 ?? 0) - 0.2841) < 0.0001)
+        #expect(abs((gradient.x2 ?? 0) - 1.03216) < 0.0001)
+        #expect(abs((gradient.y2 ?? 0) - 0.64511) < 0.0001)
+    }
+
+    @Test
+    func parseCoordinatesWithoutPercentage() throws {
+        let element = XML.Element(name: "linearGradient", attributes: [
+            "id": "b",
+            "x1": "0",
+            "y1": "0.5",
+            "x2": "1",
+            "y2": "0.5"
+        ])
+        let gradient = try XMLParser().parseLinearGradient(element)
+        #expect(gradient.x1 == 0)
+        #expect(gradient.y1 == 0.5)
+        #expect(gradient.x2 == 1)
+        #expect(gradient.y2 == 0.5)
+    }
+
+    @Test
     func parseFile() throws {
         let dom = try DOM.SVG.parse(fileNamed: "linearGradient.svg", in: .test)
 

--- a/DOM/Tests/Parser.XML.RadialGradientTests.swift
+++ b/DOM/Tests/Parser.XML.RadialGradientTests.swift
@@ -51,6 +51,23 @@ struct ParserXMLRadialGradientTests {
     }
 
     @Test
+    func parseCoordinatesWithPercentage() throws {
+        let element = XML.Element.makeMockGradient()
+        element.attributes["r"] = "10%"
+        element.attributes["cx"] = "50%"
+        element.attributes["cy"] = "25%"
+        element.attributes["fx"] = "50%"
+        element.attributes["fy"] = "25%"
+
+        let gradient = try XMLParser().parseRadialGradient(element)
+        #expect(abs((gradient.r ?? 0) - 0.1) < 0.0001)
+        #expect(abs((gradient.cx ?? 0) - 0.5) < 0.0001)
+        #expect(abs((gradient.cy ?? 0) - 0.25) < 0.0001)
+        #expect(abs((gradient.fx ?? 0) - 0.5) < 0.0001)
+        #expect(abs((gradient.fy ?? 0) - 0.25) < 0.0001)
+    }
+
+    @Test
     func parseCoordinates() throws {
         let element = XML.Element.makeMockGradient()
         element.attributes["r"] = "0.1"


### PR DESCRIPTION
### Problem
linearGradient and radialGradient elements frequently use percentage values for their geometry attributes (x1, y1, x2, y2, cx, cy, r, fx, fy, fr). Per SVG 1.1 §13.2.2, with the default gradientUnits="objectBoundingBox", 50% is equivalent to
the fraction 0.5.

SwiftDraw's scanCoordinate only recognised px/in/cm/mm/pt/pc as unit suffixes. The % was left unconsumed and the bare number was returned — so x1="3.309%" became 3.309 instead of 0.03309, placing the gradient axis far outside the bounding box
and rendering the wrong colours.

### Solution
Added scanCoordinateOrPercentage() to XMLParser.Scanner — identical to scanCoordinate but consumes a trailing % and divides the value by 100. The new method is wired through AttributeValueParser and used exclusively in the linear and radial
gradient parsers.

Generic coordinate parsing is intentionally left unchanged: % on non-gradient attributes (e.g. <rect width="50%">) is viewport-relative and requires resolution context that doesn't exist in the parser layer yet.

### Testing
- New unit tests covering percentage x1/y1/x2/y2 parsing in ParserXMLLinearGradientTests and percentage cx/cy/r/fx/fy in ParserXMLRadialGradientTests
- Existing non-percentage gradient tests confirm no regression

### Examples

Demo SVG:
<img width="320" height="220" alt="gradient_demo" src="https://github.com/user-attachments/assets/79d803eb-14db-4a16-b218-fceb24e41b4c" />

| Safari rendering | Previous rendering | Fixed |
| --- | --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-08 at 13 08 11" src="https://github.com/user-attachments/assets/1d88b807-3bbf-4287-8e94-9d55be2ac490" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-08 at 11 59 05" src="https://github.com/user-attachments/assets/af0a86e0-aa1d-41f4-8375-778d0cb049c3" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-08 at 11 57 56" src="https://github.com/user-attachments/assets/1d4b3a72-403e-41a1-a768-69070cbfc4d2" /> |
