### PR TITLE
AsyncSVGView

### DIFF
--- a/DOM/Sources/Parser.XML.Element.swift
+++ b/DOM/Sources/Parser.XML.Element.swift
@@ -118,6 +118,8 @@ extension XMLParser {
             .map { ($0, parent: nil) }
 
         while let (element, parent) = stack.popLast() {
+            try Task.checkCancellation()
+
             guard let ge = try parseGraphicsElement(element) else {
                 continue
             }

--- a/DOM/Tests/Parser.SVGTests.swift
+++ b/DOM/Tests/Parser.SVGTests.swift
@@ -287,4 +287,25 @@ struct ParserSVGTests {
             </svg>
             """#)
     }
+
+    @Test
+    func parsingGraphicsElementsChecksCancellation() async {
+        let task = Task {
+            withUnsafeCurrentTask { task in
+                task?.cancel()
+            }
+
+            _ = try DOM.SVG.parse(xml: #"""
+                <svg width="64" height="64">
+                    <g>
+                        <circle cx="32" cy="32" r="16" />
+                    </g>
+                </svg>
+                """#)
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
 }

--- a/Examples/Sources/GalleryView.swift
+++ b/Examples/Sources/GalleryView.swift
@@ -35,7 +35,6 @@ import SwiftUI
 struct GalleryView: View {
 
     var images = [
-        "spider.svg",
         "thats-no-moon.svg",
         "heliocentric.svg",
         "every-grain.svg",
@@ -64,6 +63,10 @@ struct GalleryView: View {
             LazyVStack(spacing: 20) {
                 SVGView("spider.svg", bundle: .samples)
                     .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+
+                AsyncSVGView(url: URL(string: "https://raw.githubusercontent.com/swhitty/SwiftDraw/refs/heads/main/Samples.bundle/spider.svg"))
                     .resizable()
                     .scaledToFit()
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ var body: some View {
 }
 ```
 
+Remote SVGs can be loaded using `AsyncSVGView`:
+
+```swift
+AsyncSVGView(url: URL(string: "https://example.com/image.svg"))
+    .resizable()
+    .scaledToFit()
+```
+
+For custom loading and error states, use the phase-based initializer:
+
+```swift
+AsyncSVGView(url: url) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let svg):
+        SVGView(svg: svg)
+    case .failure:
+        Image(systemName: "exclamationmark.triangle")
+    }
+}
+```
+
 ### Loading and Transforming SVGs
 
 SVG images can be loaded and rasterized to `UIImage` or `NSImage`:

--- a/SwiftDraw/Sources/AsyncSVGView.swift
+++ b/SwiftDraw/Sources/AsyncSVGView.swift
@@ -1,0 +1,273 @@
+//
+//  AsyncSVGView.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 18/7/26.
+//  Copyright 2026 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#if canImport(SwiftUI)
+public import SwiftUI
+import Foundation
+
+private extension EnvironmentValues {
+    @Entry var asyncSVGURLSession: URLSession = .shared
+}
+
+public extension View {
+    /// Sets the URL session used by `AsyncSVGView` instances in this view hierarchy.
+    func asyncSVGURLSession(_ session: URLSession) -> some View {
+        environment(\.asyncSVGURLSession, session)
+    }
+}
+
+/// The current result of loading an SVG asynchronously.
+public enum AsyncSVGPhase: Sendable {
+    /// No SVG has been loaded yet.
+    case empty
+
+    /// An SVG was loaded successfully.
+    case success(SVG)
+
+    /// Loading or parsing the SVG failed.
+    case failure(any Error)
+
+    /// The successfully loaded SVG, if one is available.
+    public var svg: SVG? {
+        guard case let .success(svg) = self else { return nil }
+        return svg
+    }
+
+    /// The loading or parsing error, if one occurred.
+    public var error: (any Error)? {
+        guard case let .failure(error) = self else { return nil }
+        return error
+    }
+}
+
+/// A view that asynchronously loads and displays a remote SVG.
+public struct AsyncSVGView<Content>: View where Content: View {
+
+    private let request: URLRequest?
+    private let options: SVG.Options
+    private let transaction: Transaction
+    private let content: (AsyncSVGPhase, SVGViewConfiguration) -> Content
+    private var svgViewConfiguration = SVGViewConfiguration()
+
+    @Environment(\.asyncSVGURLSession) private var session
+    @State private var phase: AsyncSVGPhase = .empty
+    @State private var phaseRequestID: RequestID?
+
+    /// Loads and displays an SVG from a URL.
+    public init(
+        url: URL?,
+        options: SVG.Options = .default
+    ) where Content == SVGView? {
+        self.init(request: url.map { URLRequest(url: $0) }, options: options)
+    }
+
+    /// Loads and displays an SVG using a URL request.
+    public init(
+        request: URLRequest?,
+        options: SVG.Options = .default
+    ) where Content == SVGView? {
+        self.request = request
+        self.options = options
+        self.transaction = Transaction()
+        self.content = { phase, configuration in
+            phase.svg.map {
+                configuration.apply(to: SVGView(svg: $0))
+            }
+        }
+    }
+
+    /// Sets the resizing behavior of the `SVGView` created by the default
+    /// initializer.
+    public func resizable(
+        capInsets: EdgeInsets = EdgeInsets(),
+        resizingMode: SVGView.ResizingMode = .stretch
+    ) -> Self where Content == SVGView? {
+        var copy = self
+        copy.svgViewConfiguration.resizable = (capInsets, resizingMode)
+        return copy
+    }
+
+    /// Loads an SVG and supplies it or a placeholder to the respective closure.
+    public init<I, P>(
+        url: URL?,
+        options: SVG.Options = .default,
+        @ViewBuilder content: @escaping (SVG) -> I,
+        @ViewBuilder placeholder: @escaping () -> P
+    ) where Content == _ConditionalContent<I, P>, I: View, P: View {
+        self.init(
+            request: url.map { URLRequest(url: $0) },
+            options: options,
+            content: content,
+            placeholder: placeholder
+        )
+    }
+
+    /// Loads an SVG using a URL request and supplies it or a placeholder to the
+    /// respective closure.
+    public init<I, P>(
+        request: URLRequest?,
+        options: SVG.Options = .default,
+        @ViewBuilder content: @escaping (SVG) -> I,
+        @ViewBuilder placeholder: @escaping () -> P
+    ) where Content == _ConditionalContent<I, P>, I: View, P: View {
+        self.init(request: request, options: options) { phase in
+            if let svg = phase.svg {
+                content(svg)
+            } else {
+                placeholder()
+            }
+        }
+    }
+
+    /// Loads an SVG and supplies the current loading phase to a custom view builder.
+    public init(
+        url: URL?,
+        options: SVG.Options = .default,
+        transaction: Transaction = Transaction(),
+        @ViewBuilder content: @escaping (AsyncSVGPhase) -> Content
+    ) {
+        self.init(
+            request: url.map { URLRequest(url: $0) },
+            options: options,
+            transaction: transaction,
+            content: content
+        )
+    }
+
+    /// Loads an SVG using a URL request and supplies the current loading phase
+    /// to a custom view builder.
+    public init(
+        request: URLRequest?,
+        options: SVG.Options = .default,
+        transaction: Transaction = Transaction(),
+        @ViewBuilder content: @escaping (AsyncSVGPhase) -> Content
+    ) {
+        self.request = request
+        self.options = options
+        self.transaction = transaction
+        self.content = { phase, _ in content(phase) }
+    }
+
+    public var body: some View {
+        ZStack {
+            content(phase, svgViewConfiguration)
+        }
+        .compatibilityTask(id: requestID) {
+            await loadIfNeeded(for: requestID, session: session)
+        }
+    }
+
+    private var requestID: RequestID {
+        RequestID(
+            request: request,
+            options: options.rawValue,
+            session: ObjectIdentifier(session)
+        )
+    }
+
+    @MainActor
+    private func loadIfNeeded(for requestID: RequestID, session: URLSession) async {
+        guard phaseRequestID != requestID || phase.svg == nil else { return }
+        phaseRequestID = requestID
+
+        guard let request = requestID.request else {
+            setPhase(.empty)
+            return
+        }
+
+        let options = SVG.Options(rawValue: requestID.options)
+        setPhase(.empty)
+
+        do {
+            let svg = try await AsyncSVGLoader.load(
+                from: request,
+                options: options,
+                session: session
+            )
+            try Task.checkCancellation()
+            guard phaseRequestID == requestID else { return }
+            setPhase(.success(svg))
+        } catch {
+            guard !Task.isCancelled, phaseRequestID == requestID else { return }
+            setPhase(.failure(error))
+        }
+    }
+
+    @MainActor
+    private func setPhase(_ phase: AsyncSVGPhase) {
+        withTransaction(transaction) {
+            self.phase = phase
+        }
+    }
+
+    private struct RequestID: Hashable {
+        var request: URLRequest?
+        var options: Int
+        var session: ObjectIdentifier
+    }
+
+    private struct SVGViewConfiguration {
+        var resizable: (capInsets: EdgeInsets, mode: SVGView.ResizingMode)?
+
+        @MainActor
+        func apply(to view: SVGView) -> SVGView {
+            guard let resizable else { return view }
+            return view.resizable(
+                capInsets: resizable.capInsets,
+                resizingMode: resizable.mode
+            )
+        }
+    }
+}
+
+enum AsyncSVGLoader {
+
+    static func load(
+        from request: URLRequest,
+        options: SVG.Options,
+        session: URLSession = .shared
+    ) async throws -> SVG {
+        try Task.checkCancellation()
+        let (data, response) = try await session.data(for: request)
+        try validate(response)
+        try Task.checkCancellation()
+        return try SVG(parsing: data, options: options)
+    }
+
+    static func validate(_ response: URLResponse) throws {
+        guard let response = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(response.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+}
+
+#endif

--- a/SwiftDraw/Sources/SVG.swift
+++ b/SwiftDraw/Sources/SVG.swift
@@ -85,11 +85,11 @@ public struct SVG: Hashable, Sendable {
     }
 
     public init?(data: Data, options: SVG.Options = .default) {
-        guard let svg = try? DOM.SVG.parse(data: data) else { return nil }
-        self.init(dom: svg, options: options)
+        guard let svg = try? SVG(parsing: data, options: options) else { return nil }
+        self = svg
     }
 
-    public struct Options: OptionSet {
+    public struct Options: OptionSet, Sendable {
         public let rawValue: Int
         public init(rawValue: Int) {
             self.rawValue = rawValue
@@ -153,6 +153,11 @@ public extension SVG {
 }
 
 extension SVG {
+
+    init(parsing data: Data, options: Options) throws {
+        let svg = try DOM.SVG.parse(data: data)
+        self.init(dom: svg, options: options)
+    }
 
     init(dom: DOM.SVG, options: Options) {
         self.size = CGSize(width: dom.width, height: dom.height)

--- a/SwiftDraw/Sources/View+Task.swift
+++ b/SwiftDraw/Sources/View+Task.swift
@@ -1,0 +1,94 @@
+//
+//  View+Task.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 19/7/26.
+//  Copyright 2026 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#if canImport(SwiftUI)
+import Combine
+import SwiftUI
+
+extension View {
+
+    @ViewBuilder
+    func compatibilityTask<ID: Equatable>(
+        id: ID,
+        priority: TaskPriority = .userInitiated,
+        @_inheritActorContext _ action: @escaping @Sendable () async -> Void
+    ) -> some View {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            task(id: id, priority: priority, action)
+        } else {
+            modifier(CompatibilityTaskModifier(
+                id: id,
+                priority: priority,
+                action: action
+            ))
+        }
+    }
+}
+
+private struct CompatibilityTaskModifier<ID: Equatable>: ViewModifier {
+
+    let id: ID
+    let priority: TaskPriority
+    let action: @Sendable () async -> Void
+
+    @State private var currentID: ID?
+    @State private var isVisible = false
+    @State private var task: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                isVisible = true
+                startTaskIfNeeded(id: id)
+            }
+            .onReceive(Just(id)) { id in
+                guard isVisible else { return }
+                startTaskIfNeeded(id: id)
+            }
+            .onDisappear {
+                isVisible = false
+                currentID = nil
+                task?.cancel()
+                task = nil
+            }
+    }
+
+    private func startTaskIfNeeded(id: ID) {
+        guard currentID != id else { return }
+        currentID = id
+        task?.cancel()
+        task = Task(priority: priority) {
+            await action()
+        }
+    }
+}
+
+#endif

--- a/SwiftDraw/Tests/AsyncSVGViewTests.swift
+++ b/SwiftDraw/Tests/AsyncSVGViewTests.swift
@@ -1,0 +1,149 @@
+//
+//  AsyncSVGViewTests.swift
+//  SwiftDraw
+//
+//  Created by Simon Whitty on 18/7/26.
+//  Copyright 2026 Simon Whitty
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/SwiftDraw
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#if canImport(SwiftUI)
+import Foundation
+@testable import SwiftDraw
+import Testing
+
+struct AsyncSVGViewTests {
+
+    @Test
+    func phaseExposesSVGAndError() throws {
+        let svg = try #require(SVG(xml: Self.validSVG))
+
+        #expect(AsyncSVGPhase.empty.svg == nil)
+        #expect(AsyncSVGPhase.empty.error == nil)
+
+        let success = AsyncSVGPhase.success(svg)
+        #expect(success.svg == svg)
+        #expect(success.error == nil)
+
+        let failure = AsyncSVGPhase.failure(URLError(.timedOut))
+        #expect(failure.svg == nil)
+        #expect((failure.error as? URLError)?.code == .timedOut)
+    }
+
+    @Test
+    func loaderUsesURLRequestAndURLSession() async throws {
+        var request = URLRequest(url: URL(string: "https://example.invalid/image.svg")!)
+        request.setValue("SwiftDraw", forHTTPHeaderField: "X-Loader")
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SVGTestURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let loaded = try await AsyncSVGLoader.load(
+            from: request,
+            options: .hideUnsupportedFilters,
+            session: session
+        )
+
+        #expect(loaded.size.width == 20)
+        #expect(loaded.size.height == 10)
+    }
+
+    @Test
+    func loaderRejectsHTTPFailure() throws {
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com/image.svg")!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        do {
+            try AsyncSVGLoader.validate(response)
+            Issue.record("Expected an unsuccessful HTTP response to throw")
+        } catch let error as URLError {
+            #expect(error.code == .badServerResponse)
+        }
+    }
+
+    @Test
+    func loaderAcceptsSuccessfulHTTPResponse() throws {
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com/image.svg")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        #expect(throws: Never.self) {
+            try AsyncSVGLoader.validate(response)
+        }
+    }
+
+    private static let validSVG = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+      <rect width="20" height="10" fill="red" />
+    </svg>
+    """
+}
+
+private final class SVGTestURLProtocol: URLProtocol, @unchecked Sendable {
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "example.invalid"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let statusCode = request.value(forHTTPHeaderField: "X-Loader") == "SwiftDraw" ? 200 : 400
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "image/svg+xml"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.svgData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() { }
+
+    private static let svgData = Data("""
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+      <rect width="20" height="10" fill="red" />
+    </svg>
+    """.utf8)
+}
+#endif


### PR DESCRIPTION
Adds `AsyncSVGView` which functions just like `AsyncImage` allowing remote SVGs to be loaded from a view

```swift
AsyncSVGView(url: URL(string: "https://example.com/image.svg"))
    .resizable()
    .scaledToFit()
```

Provide custom view for the loading phase:

```swift
AsyncSVGView(url: url) { phase in
    switch phase {
    case .empty:
        ProgressView()
    case .success(let svg):
        SVGView(svg: svg)
            .resizable()
            .scaledToFit()
    case .failure:
        Image(systemName: "exclamationmark.triangle")
    }
}
```

Use a `URLRequest` for per-request configuration, or provide a custom
`URLSession` to a view hierarchy:

```swift
let request = URLRequest(
    url: url,
    cachePolicy: .returnCacheDataElseLoad
)

AsyncSVGView(request: request)
    .asyncSVGURLSession(imageSession)
```